### PR TITLE
fix(openpyxl): Обновлена версия openpyxl в зависимостях до 3.1.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ psycopg2-binary = "^2.9.6"
 sentry-sdk = "^1.39.0"
 gunicorn = "^21.2.0"
 python-dotenv = "^1.0.1"
-openpyxl = "^3.1.2"
+openpyxl = "^3.1.3"
 
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
Обновлена версия openpyxl в зависимостях до 3.1.3 для того, чтобы убрать DeprecatedWarning при тестировании