### PR TITLE
fix: Добавлена проверка владельца записи в VisitedCity_Update

### DIFF
--- a/city/views.py
+++ b/city/views.py
@@ -165,12 +165,22 @@ class VisitedCity_Update(LoginRequiredMixin, UpdateView):
 
      > Доступ только для авторизованных пользователей (LoginRequiredMixin).
      > Доступ только к тем городам, которые пользователь уже посетил (обрабатывается в методе dispatch).
-       При попытке получить доступ к непосещённому городу - возвращаем ошибку 403.
+       При попытке получить доступ к непосещённому городу - возвращаем ошибку 404.
     """
 
     model = VisitedCity
     form_class = VisitedCity_Create_Form
     template_name = 'city/city_create.html'
+
+    def dispatch(self, request: HttpRequest, *args: Any, **kwargs: Any) -> HttpResponseBase:
+        """Проверяем права доступа перед обработкой запроса."""
+        if not get_visited_city(request.user.pk, self.kwargs['pk']):
+            logger.warning(
+                request,
+                f'(Visited city) Attempt to update a non-existent visited city #{self.kwargs["pk"]}',
+            )
+            raise Http404
+        return super().dispatch(request, *args, **kwargs)
 
     def get_initial(self) -> dict[str, Any]:
         """


### PR DESCRIPTION
## Описание

Исправлена критическая уязвимость безопасности в представлении `VisitedCity_Update`, которая позволяла любому авторизованному пользователю редактировать чужие записи о посещённых городах.

## Изменения

- ✅ Добавлен метод `dispatch()` с проверкой прав доступа
- ✅ Используется функция `get_visited_city(user_id, city_id)` для проверки владельца записи
- ✅ При попытке доступа к чужой записи возвращается HTTP 404
- ✅ Добавлено логирование предупреждений о попытках несанкционированного доступа
- ✅ Исправлена опечатка в docstring (403 → 404)

## Проблема

До исправления любой авторизованный пользователь мог:
- Открыть форму редактирования чужой записи через GET запрос
- Изменить данные другого пользователя через POST запрос

## Решение

Добавлена проверка владельца записи в методе `dispatch()`, аналогично тому, как это реализовано в `VisitedCity_Delete`.

## Код изменений

```python
def dispatch(self, request: HttpRequest, *args: Any, **kwargs: Any) -> HttpResponseBase:
    """Проверяем права доступа перед обработкой запроса."""
    if not get_visited_city(request.user.pk, self.kwargs['pk']):
        logger.warning(
            request,
            f'(Visited city) Attempt to update a non-existent visited city #{self.kwargs["pk"]}',
        )
        raise Http404
    return super().dispatch(request, *args, **kwargs)
```

## Тип изменений

- [x] 🐛 Исправление ошибки (bug fix)
- [x] 🔒 Исправление безопасности (security fix)

## Тестирование

После слияния этого PR необходимо обновить тесты в ветке `refactoring_tests`, которые в данный момент документируют неправильное поведение с TODO комментариями.