### PR TITLE
fix(collections): Исправлена статистика посещённых городов в персональных коллекциях

### DIFF
--- a/collection/views.py
+++ b/collection/views.py
@@ -524,6 +524,7 @@ class PersonalCollectionCityListView(ListView):  # type: ignore[type-arg]
             collection=self.collection,
             cities=cities,
             filter_param=self._statistics.get('filter', ''),
+            statistics=self._statistics,
         )
 
         # Обновляем контекст (service_context не содержит object_list, поэтому он не перезапишется)


### PR DESCRIPTION
- Статистика теперь считается из всей коллекции до пагинации
- Добавлен подсчет общего количества городов и посещённых городов в get_cities_for_collection
- Статистика передаётся через параметр statistics в get_list_context_data
- Теперь на всех страницах отображается правильное общее количество (например, "1 из 18" вместо "0 из 16" на первой странице)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Обновляет логику подсчёта статистики персональной коллекции, чтобы числа не зависели от пагинации/фильтра.
> 
> - В `get_cities_for_collection` считаются `qty_of_cities` и `qty_of_visited_cities` до применения фильтра/пагинации и возвращаются в `statistics` вместе с `filter`
> - `get_list_context_data` принимает опциональный `statistics` и использует общие значения; добавлен безопасный fallback к пагинированному списку
> - `PersonalCollectionCityListView` теперь передаёт `statistics` в сервис при формировании контекста, обеспечивая корректный вывод (например, «1 из 18»)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bea60990a3fb1ebd1c8bfc3b13eb352f77e0c39f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->