### PR TITLE
fix(collections): Исправлено отображение цветов бейджей городов в персональных коллекциях

### DIFF
--- a/collection/views.py
+++ b/collection/views.py
@@ -418,6 +418,12 @@ class PersonalCollectionListView(LoginRequiredMixin, ListView):  # type: ignore[
         """
         context = super().get_context_data(**kwargs)
 
+        # Получаем список ID городов, которые посещены пользователем
+        user = cast(User, self.request.user)
+        context['visited_cities'] = list(
+            VisitedCity.objects.filter(user=user).values_list('city__id', flat=True)
+        )
+
         context['active_page'] = 'collection'
         context['page_title'] = 'Персональные коллекции'
         context['page_description'] = (


### PR DESCRIPTION
- Добавлена передача visited_cities в контекст для PersonalCollectionListView
- Теперь посещённые города отображаются зелёным цветом, непосещённые - красным
- Исправлена проблема, когда все города отображались красным цветом

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures personal collections list can correctly highlight visited vs. unvisited cities.
> 
> - In `PersonalCollectionListView.get_context_data`, add `visited_cities` (IDs from `VisitedCity` for the current user) to the context for template use
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 346badb7d7c4bb88b20be2eecc1bee26732b2308. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->