### PR TITLE
fix: Кнопка вызова окна уведомлений на мобильных устройствах привязана к модальному окну

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -49,6 +49,7 @@
                             <button type="button"
                                     class="relative inline-flex items-center justify-center rounded-lg p-2 text-gray-600 border border-gray-200 hover:bg-gray-100 hover:text-gray-900 hover:border-gray-300 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:text-neutral-400 dark:border-neutral-700 dark:hover:bg-neutral-800 dark:hover:text-neutral-200 dark:hover:border-neutral-600 cursor-pointer"
                                     id="notification_icon"
+                                    data-hs-overlay="#notificationModal"
                                     aria-label="Открыть уведомления">
                                 <svg class="h-6 w-6" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24" aria-hidden="true" id="bell">
                                     <path stroke-linecap="round" stroke-linejoin="round" d="M14.857 17.082a23.848 23.848 0 005.454-1.31A8.967 8.967 0 0118 9.75v-.7V9A6 6 0 006 9v.75a8.967 8.967 0 01-2.312 6.022c1.733.64 3.56 1.085 5.455 1.31m5.714 0a24.255 24.255 0 01-5.714 0m5.714 0a3 3 0 11-5.714 0" />


### PR DESCRIPTION
## Изменения

- Добавлен атрибут `data-hs-overlay="#notificationModal"` к кнопке открытия уведомлений в `base.html`, чтобы привязать иконку колокольчика к модальному окну уведомлений.

## Зачем это нужно

- Теперь нажатие на иконку уведомлений будет корректно открывать модальное окно `notificationModal`, что улучшает UX и делает поведение интерфейса ожидаемым для пользователя.

## Тестирование

- Открыть любую страницу, использующую `base.html`.
- Нажать на иконку уведомлений (колокольчик) в шапке.
- Убедиться, что открывается модальное окно `notificationModal`.
- Закрыть модальное окно и проверить, что повторное нажатие снова корректно его открывает.