### PR TITLE
feat: Карусель изображений в статьях блога

### DIFF
--- a/MoiGoroda/settings.py
+++ b/MoiGoroda/settings.py
@@ -465,14 +465,22 @@ TINYMCE_DEFAULT_CONFIG = {
         'content: attr(data-mg-caption); display: block; clear: both; '
         'text-align: center; font-size: 12px; line-height: 1.25; color: #6b7280; '
         'margin-top: 0.5em; padding: 0 0.25em; '
-        '}'
+        '} '
+        'body img:not(.mg-blog-carousel img) { '
+        'max-width: 200px !important; max-height: 200px !important; '
+        'width: auto !important; height: auto !important; '
+        '} '
+        'img[data-mg-content-sized] { max-width: 100%; height: auto; }'
     ),
     'images_upload_url': '/tinymce/upload-image/',
     'images_upload_handler': 'djangoTinyMCEImagesUploadHandler',
     'automatic_uploads': True,
     'setup': 'djangoTinyMCESetup',
     # Сохранять div-маркеры рекламы и карусели
-    'extended_valid_elements': 'div[class|data-ad|contenteditable|data-mg-blog-carousel|data-mg-caption]',
+    'extended_valid_elements': (
+        'div[class|data-ad|contenteditable|data-mg-blog-carousel|data-mg-caption],'
+        'img[class|src|alt|width|height|data-mg-content-sized]'
+    ),
 }
 
 TINYMCE_EXTRA_MEDIA = {
@@ -480,6 +488,7 @@ TINYMCE_EXTRA_MEDIA = {
         'tinymce/js/tinymce_csrf_upload.js',
         'tinymce/js/tinymce_rtb_button.js',
         'tinymce/js/tinymce_blog_carousel_multiselect.js',
+        'tinymce/js/tinymce_content_image.js',
         'tinymce/js/tinymce_setup.js',
     ],
 }

--- a/MoiGoroda/settings.py
+++ b/MoiGoroda/settings.py
@@ -460,6 +460,11 @@ TINYMCE_DEFAULT_CONFIG = {
         '.mg-blog-carousel img { '
         'display: inline-block; max-width: 120px; max-height: 80px; '
         'object-fit: cover; margin: 0 4px 4px 0; border-radius: 4px; vertical-align: top; '
+        '} '
+        '.mg-blog-carousel[data-mg-caption]::after { '
+        'content: attr(data-mg-caption); display: block; clear: both; '
+        'text-align: center; font-size: 12px; line-height: 1.25; color: #6b7280; '
+        'margin-top: 0.5em; padding: 0 0.25em; '
         '}'
     ),
     'images_upload_url': '/tinymce/upload-image/',
@@ -467,7 +472,7 @@ TINYMCE_DEFAULT_CONFIG = {
     'automatic_uploads': True,
     'setup': 'djangoTinyMCESetup',
     # Сохранять div-маркеры рекламы и карусели
-    'extended_valid_elements': 'div[class|data-ad|contenteditable|data-mg-blog-carousel]',
+    'extended_valid_elements': 'div[class|data-ad|contenteditable|data-mg-blog-carousel|data-mg-caption]',
 }
 
 TINYMCE_EXTRA_MEDIA = {

--- a/MoiGoroda/settings.py
+++ b/MoiGoroda/settings.py
@@ -436,7 +436,8 @@ TINYMCE_DEFAULT_CONFIG = {
     'plugins': 'advlist autolink lists link image charmap anchor searchreplace visualblocks code '
     'fullscreen insertdatetime media table help wordcount',
     'toolbar': 'undo redo | blocks | bold italic | alignleft aligncenter alignright | '
-    'bullist numlist outdent indent | link image | rtb_banner_inside_article_1 rtb_banner_inside_article_2 rtb_banner_inside_article_3 | removeformat | help',
+    'bullist numlist outdent indent | link image blog_carousel | '
+    'rtb_banner_inside_article_1 rtb_banner_inside_article_2 rtb_banner_inside_article_3 | removeformat | help',
     'content_style': (
         'body { font-family:Helvetica,Arial,sans-serif; font-size:14px } '
         '.ad-placeholder-rtb-banner { '
@@ -447,20 +448,34 @@ TINYMCE_DEFAULT_CONFIG = {
         '.ad-placeholder-rtb-banner[data-ad="rtb_banner_inside_article_1"]::before { content: "Рекламный блок 1"; font-weight: 600; } '
         '.ad-placeholder-rtb-banner[data-ad="rtb_banner_inside_article_2"]::before { content: "Рекламный блок 2"; font-weight: 600; } '
         '.ad-placeholder-rtb-banner[data-ad="rtb_banner_inside_article_3"]::before { content: "Рекламный блок 3"; font-weight: 600; } '
-        '.ad-placeholder-rtb-banner:not([data-ad])::before { content: "Рекламный блок"; font-weight: 600; }'
+        '.ad-placeholder-rtb-banner:not([data-ad])::before { content: "Рекламный блок"; font-weight: 600; } '
+        '.mg-blog-carousel { '
+        'display: block; margin: 1em 0; padding: 0.75em; '
+        'background: #e8f4fd; border: 1px dashed #0d6efd; border-radius: 6px; '
+        '} '
+        '.mg-blog-carousel::before { '
+        'content: "Карусель фотографий"; display: block; font-weight: 600; '
+        'font-size: 13px; color: #0d6efd; margin-bottom: 0.5em; '
+        '} '
+        '.mg-blog-carousel img { '
+        'display: inline-block; max-width: 120px; max-height: 80px; '
+        'object-fit: cover; margin: 0 4px 4px 0; border-radius: 4px; vertical-align: top; '
+        '}'
     ),
     'images_upload_url': '/tinymce/upload-image/',
     'images_upload_handler': 'djangoTinyMCEImagesUploadHandler',
     'automatic_uploads': True,
-    'setup': 'djangoTinyMCESetupRtbBanner',
-    # Сохранять div-маркер рекламы (кнопка «Рекламный блок»)
-    'extended_valid_elements': 'div[class|data-ad]',
+    'setup': 'djangoTinyMCESetup',
+    # Сохранять div-маркеры рекламы и карусели
+    'extended_valid_elements': 'div[class|data-ad|contenteditable|data-mg-blog-carousel]',
 }
 
 TINYMCE_EXTRA_MEDIA = {
     'js': [
         'tinymce/js/tinymce_csrf_upload.js',
         'tinymce/js/tinymce_rtb_button.js',
+        'tinymce/js/tinymce_blog_carousel_multiselect.js',
+        'tinymce/js/tinymce_setup.js',
     ],
 }
 

--- a/MoiGoroda/settings.py
+++ b/MoiGoroda/settings.py
@@ -466,9 +466,29 @@ TINYMCE_DEFAULT_CONFIG = {
         'text-align: center; font-size: 12px; line-height: 1.25; color: #6b7280; '
         'margin-top: 0.5em; padding: 0 0.25em; '
         '} '
+        'body p:has(> img:not(.mg-blog-carousel img)), '
+        'body figure:has(> img:not(.mg-blog-carousel img)) { '
+        'display: block; width: 100%; margin: 0 0 1em; text-align: center; '
+        '} '
+        'body p[data-mg-caption]:not(:has(.mg-blog-carousel))::after, '
+        'body figure[data-mg-caption]:not(:has(.mg-blog-carousel))::after { '
+        'content: attr(data-mg-caption); display: block; clear: both; '
+        'text-align: center; font-size: 12px; line-height: 1.25; color: #6b7280; '
+        'margin-top: 0.25em; padding: 0 0.25em; '
+        '} '
         'body img:not(.mg-blog-carousel img) { '
+        'display: block !important; float: none !important; clear: both !important; '
+        'margin: 0.5em auto !important; '
         'max-width: 200px !important; max-height: 200px !important; '
         'width: auto !important; height: auto !important; '
+        '} '
+        'body img:not(.mg-blog-carousel img)[data-mg-caption] { '
+        'display: block; margin-left: auto; margin-right: auto; '
+        '} '
+        'body img:not(.mg-blog-carousel img)[data-mg-caption]::after { '
+        'content: attr(data-mg-caption); display: block; '
+        'text-align: center; font-size: 12px; line-height: 1.25; color: #6b7280; '
+        'margin-top: 0.25em; padding: 0 0.25em; '
         '} '
         'img[data-mg-content-sized] { max-width: 100%; height: auto; }'
     ),
@@ -479,7 +499,8 @@ TINYMCE_DEFAULT_CONFIG = {
     # Сохранять div-маркеры рекламы и карусели
     'extended_valid_elements': (
         'div[class|data-ad|contenteditable|data-mg-blog-carousel|data-mg-caption],'
-        'img[class|src|alt|width|height|data-mg-content-sized]'
+        'p[data-mg-caption],figure[data-mg-caption],'
+        'img[class|src|alt|width|height|data-mg-content-sized|data-mg-caption]'
     ),
 }
 

--- a/blog/tests/test_templatetags.py
+++ b/blog/tests/test_templatetags.py
@@ -95,9 +95,9 @@ class ContentWithAdsTagTests(TestCase):
     def test_preserves_blog_carousel_markup(self) -> None:
         html = (
             '<p>Текст</p>'
-            '<div class="mg-blog-carousel" data-mg-blog-carousel>'
-            '<img src="https://example.com/a.jpg" alt="Фото 1">'
-            '<img src="https://example.com/b.jpg" alt="Фото 2">'
+            '<div class="mg-blog-carousel" data-mg-blog-carousel data-mg-caption="Подпись">'
+            '<img src="https://example.com/a.jpg" alt="Подпись">'
+            '<img src="https://example.com/b.jpg" alt="Подпись">'
             '</div>'
         )
         result = content_ads.content_with_ads(self.context, html, 'dummy.html')
@@ -105,6 +105,7 @@ class ContentWithAdsTagTests(TestCase):
 
         self.assertIn('mg-blog-carousel', rendered)
         self.assertIn('data-mg-blog-carousel', rendered)
+        self.assertIn('data-mg-caption="Подпись"', rendered)
         self.assertIn('https://example.com/a.jpg', rendered)
         self.assertIn('https://example.com/b.jpg', rendered)
 

--- a/blog/tests/test_templatetags.py
+++ b/blog/tests/test_templatetags.py
@@ -91,3 +91,39 @@ class ContentWithAdsTagTests(TestCase):
 
         self.assertEqual(rendered.count('[AD]'), 2)
         self.assertEqual(rendered.count('ad-insert-in-content'), 2)
+
+    def test_preserves_blog_carousel_markup(self) -> None:
+        html = (
+            '<p>Текст</p>'
+            '<div class="mg-blog-carousel" data-mg-blog-carousel>'
+            '<img src="https://example.com/a.jpg" alt="Фото 1">'
+            '<img src="https://example.com/b.jpg" alt="Фото 2">'
+            '</div>'
+        )
+        result = content_ads.content_with_ads(self.context, html, 'dummy.html')
+        rendered = str(result)
+
+        self.assertIn('mg-blog-carousel', rendered)
+        self.assertIn('data-mg-blog-carousel', rendered)
+        self.assertIn('https://example.com/a.jpg', rendered)
+        self.assertIn('https://example.com/b.jpg', rendered)
+
+    @patch('blog.templatetags.content_ads.loader.get_template')
+    def test_preserves_blog_carousel_with_ad_placeholder(self, mock_get_template: Mock) -> None:
+        mock_tpl = Mock()
+        mock_tpl.render.return_value = '[AD]'
+        mock_get_template.return_value = mock_tpl
+
+        html = (
+            '<div class="mg-blog-carousel" data-mg-blog-carousel>'
+            '<img src="https://example.com/1.jpg" alt="">'
+            '<img src="https://example.com/2.jpg" alt="">'
+            '</div>'
+            '<div class="ad-placeholder-rtb-banner" data-ad="rtb_banner_inside_article_1"></div>'
+        )
+        result = content_ads.content_with_ads(self.context, html, 'advertisement/rtb_banner.html')
+        rendered = str(result)
+
+        self.assertIn('mg-blog-carousel', rendered)
+        self.assertIn('[AD]', rendered)
+        self.assertNotIn('ad-placeholder-rtb-banner', rendered)

--- a/frontend/css/blog_content_carousel.css
+++ b/frontend/css/blog_content_carousel.css
@@ -1,0 +1,158 @@
+/**
+ * Карусель в контенте блога — тот же блок, что у одиночного изображения (500px, по центру).
+ * Стили img и подписи наследуются из content_image_gallery.css.
+ */
+.content-with-image-gallery .mg-blog-carousel {
+    display: block;
+    width: 100%;
+    margin-bottom: 1rem;
+    text-align: center;
+    box-shadow: none !important;
+}
+
+.content-with-image-gallery .mg-blog-carousel-widget {
+    box-shadow: none;
+}
+
+.content-with-image-gallery .mg-blog-carousel-swiper {
+    overflow: hidden;
+    background-color: #fff;
+}
+
+.dark .content-with-image-gallery .mg-blog-carousel-swiper {
+    background-color: rgb(23 23 23);
+}
+
+.content-with-image-gallery .mg-blog-carousel-swiper .swiper-slide {
+    overflow: hidden;
+}
+
+.content-with-image-gallery .mg-blog-carousel-slide-inner {
+    display: block;
+    width: 100%;
+    text-align: center;
+    box-shadow: none !important;
+    background-color: #fff;
+}
+
+.dark .content-with-image-gallery .mg-blog-carousel-slide-inner {
+    background-color: rgb(23 23 23);
+}
+
+.content-with-image-gallery .mg-blog-carousel-slide-inner > a {
+    display: inline-block;
+    max-width: 100%;
+}
+
+.content-with-image-gallery .mg-blog-carousel-slide-inner img.mg-blog-carousel-main-img {
+    display: block;
+    max-width: min(100%, 500px);
+    max-height: min(70vh, 500px);
+    width: auto;
+    height: auto;
+    object-fit: contain;
+    margin: 1rem auto 0.5rem;
+    border-radius: 0.75rem;
+    cursor: pointer;
+    box-shadow: none;
+}
+
+.content-with-image-gallery
+    .mg-blog-carousel-swiper
+    .swiper-slide-active
+    .mg-blog-carousel-slide-inner
+    img.mg-blog-carousel-main-img {
+    box-shadow: 0 4px 14px rgba(15, 23, 42, 0.18);
+}
+
+.content-with-image-gallery .mg-blog-carousel-live {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+}
+
+.content-with-image-gallery .mg-blog-carousel-prev,
+.content-with-image-gallery .mg-blog-carousel-next {
+    position: absolute;
+    top: 45%;
+    z-index: 10;
+    margin-top: 0 !important;
+    transform: translateY(-50%);
+}
+
+.content-with-image-gallery .mg-blog-carousel-prev::after,
+.content-with-image-gallery .mg-blog-carousel-next::after {
+    display: none !important;
+}
+
+.content-with-image-gallery .mg-blog-carousel-prev {
+    left: 0.25rem;
+}
+
+.content-with-image-gallery .mg-blog-carousel-next {
+    right: 0.25rem;
+}
+
+.content-with-image-gallery .mg-blog-carousel-thumbs-panel {
+    padding: 0.5rem 0.75rem 0;
+}
+
+.content-with-image-gallery .mg-blog-carousel-thumb img.mg-blog-carousel-thumb-img {
+    display: block;
+    width: 100%;
+    height: 100%;
+    max-width: none;
+    max-height: none;
+    margin: 0;
+    padding: 0;
+    border-radius: 0;
+    box-shadow: none;
+    object-fit: cover;
+    cursor: pointer;
+}
+
+.content-with-image-gallery .mg-blog-carousel-thumb {
+    line-height: 0;
+    vertical-align: top;
+}
+
+.content-with-image-gallery .mg-blog-carousel-thumbs:not(.swiper-initialized) {
+    display: none;
+}
+
+.content-with-image-gallery .mg-blog-carousel-main .mg-blog-carousel-swiper:not(.swiper-initialized) .swiper-slide {
+    display: none;
+}
+
+.content-with-image-gallery
+    .mg-blog-carousel-main
+    .mg-blog-carousel-swiper:not(.swiper-initialized)
+    .swiper-slide:first-child {
+    display: block;
+}
+
+.content-with-image-gallery
+    .mg-blog-carousel-main
+    .mg-blog-carousel-swiper:not(.swiper-initialized)
+    ~ .mg-blog-carousel-prev,
+.content-with-image-gallery
+    .mg-blog-carousel-main
+    .mg-blog-carousel-swiper:not(.swiper-initialized)
+    ~ .mg-blog-carousel-next {
+    opacity: 0;
+    pointer-events: none;
+}
+
+/* Превью в редакторе до инициализации на сайте */
+.content-with-image-gallery .mg-blog-carousel:not(.mg-blog-carousel--initialized) img {
+    display: inline-block;
+    max-width: 48%;
+    margin: 0.25rem;
+    vertical-align: top;
+}

--- a/frontend/css/blog_content_carousel.css
+++ b/frontend/css/blog_content_carousel.css
@@ -149,10 +149,50 @@
     pointer-events: none;
 }
 
-/* Превью в редакторе до инициализации на сайте */
-.content-with-image-gallery .mg-blog-carousel:not(.mg-blog-carousel--initialized) img {
-    display: inline-block;
-    max-width: 48%;
-    margin: 0.25rem;
-    vertical-align: top;
+/**
+ * До инициализации JS — только первое фото (без «сетки» из всех картинок).
+ * Стили совпадают с активным слайдом карусели, чтобы переход был незаметным.
+ */
+.content-with-image-gallery .mg-blog-carousel:not(.mg-blog-carousel--initialized) {
+    overflow: hidden;
+    text-align: center;
+}
+
+.content-with-image-gallery .mg-blog-carousel:not(.mg-blog-carousel--initialized) > img {
+    display: none;
+    max-width: min(100%, 500px);
+    max-height: min(70vh, 500px);
+    width: auto;
+    height: auto;
+    object-fit: contain;
+    margin: 1rem auto 0.5rem;
+    border-radius: 0.75rem;
+    box-shadow: 0 4px 14px rgba(15, 23, 42, 0.18);
+    cursor: pointer;
+}
+
+.content-with-image-gallery .mg-blog-carousel:not(.mg-blog-carousel--initialized) > img:first-of-type {
+    display: block;
+}
+
+.content-with-image-gallery .mg-blog-carousel[data-mg-caption]:not(.mg-blog-carousel--initialized)::after {
+    content: attr(data-mg-caption);
+    display: block;
+    margin: 0 auto 1rem;
+    font-size: 0.8rem;
+    line-height: 1rem;
+    color: var(--caption-color, #6b7280);
+    text-align: center;
+}
+
+.dark .content-with-image-gallery .mg-blog-carousel[data-mg-caption]:not(.mg-blog-carousel--initialized)::after {
+    --caption-color: #9ca3af;
+}
+
+.content-with-image-gallery .mg-blog-carousel.mg-blog-carousel--initializing {
+    min-height: var(--mg-blog-carousel-min-height, auto);
+}
+
+.content-with-image-gallery .mg-blog-carousel.mg-blog-carousel--initializing .mg-blog-carousel-widget {
+    visibility: hidden;
 }

--- a/frontend/css/blog_content_carousel.css
+++ b/frontend/css/blog_content_carousel.css
@@ -1,15 +1,7 @@
 /**
  * Карусель в контенте блога — тот же блок, что у одиночного изображения (500px, по центру).
- * Стили img и подписи наследуются из content_image_gallery.css.
+ * Базовые отступы — в content_image_gallery.css (подключается и в списке статей).
  */
-.content-with-image-gallery .mg-blog-carousel {
-    display: block;
-    width: 100%;
-    margin-bottom: 1rem;
-    text-align: center;
-    box-shadow: none !important;
-}
-
 .content-with-image-gallery .mg-blog-carousel-widget {
     box-shadow: none;
 }
@@ -63,18 +55,6 @@
     .mg-blog-carousel-slide-inner
     img.mg-blog-carousel-main-img {
     box-shadow: 0 4px 14px rgba(15, 23, 42, 0.18);
-}
-
-.content-with-image-gallery .mg-blog-carousel-live {
-    position: absolute;
-    width: 1px;
-    height: 1px;
-    padding: 0;
-    margin: -1px;
-    overflow: hidden;
-    clip: rect(0, 0, 0, 0);
-    white-space: nowrap;
-    border: 0;
 }
 
 .content-with-image-gallery .mg-blog-carousel-prev,

--- a/frontend/css/content_image_gallery.css
+++ b/frontend/css/content_image_gallery.css
@@ -15,15 +15,18 @@
     box-shadow: none !important;
 }
 
-.content-with-image-gallery img {
-    max-width: 100%;
-    max-height: 70vh;
+.content-with-image-gallery img:not(.mg-blog-carousel-thumb-img):not(.mg-blog-carousel-main-img) {
+    /* Как в редакторе: до 500px по большей стороне, на узком экране — 100% */
+    max-width: min(100%, 500px);
+    max-height: min(70vh, 500px);
+    width: auto;
     height: auto;
     object-fit: contain;
     display: block;
     margin: 1rem auto 0.5rem;
     box-shadow: 0 4px 14px rgba(15, 23, 42, 0.18);
     border-radius: 0.75rem;
+    cursor: pointer;
 }
 
 .content-with-image-gallery .content-image-caption {
@@ -43,4 +46,39 @@
 /* В полноэкранной галерее показываем только изображение, без подписи */
 .glightbox-container .gdesc {
     display: none !important;
+}
+
+/**
+ * Стрелки карусели в превью — те же, что .gprev / .gnext в GLightbox (тема glightbox-clean).
+ */
+.content-with-image-gallery .content-gallery-lightbox-nav {
+    width: 40px;
+    height: 50px;
+    min-width: 40px;
+    padding: 0;
+    border: none;
+    border-radius: 4px;
+    background-color: rgba(0, 0, 0, 0.32);
+    color: #fff;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    transition: background-color 0.2s ease;
+    box-shadow: none;
+}
+
+.content-with-image-gallery .content-gallery-lightbox-nav:hover {
+    background-color: rgba(0, 0, 0, 0.7);
+}
+
+.content-with-image-gallery .content-gallery-lightbox-nav svg {
+    display: block;
+    width: 25px;
+    height: auto;
+    margin: 0;
+}
+
+.content-with-image-gallery .content-gallery-lightbox-nav svg path {
+    fill: currentColor;
 }

--- a/frontend/css/content_image_gallery.css
+++ b/frontend/css/content_image_gallery.css
@@ -4,6 +4,15 @@
  */
 @import 'glightbox/dist/css/glightbox.min.css';
 
+.content-with-image-gallery .mg-blog-carousel {
+    display: block;
+    width: 100%;
+    margin-top: 1rem;
+    margin-bottom: 1rem;
+    text-align: center;
+    box-shadow: none !important;
+}
+
 .content-with-image-gallery p:has(> img),
 .content-with-image-gallery p:has(> a > img),
 .content-with-image-gallery figure:has(> img) {
@@ -46,6 +55,19 @@
 /* В полноэкранной галерее показываем только изображение, без подписи */
 .glightbox-container .gdesc {
     display: none !important;
+}
+
+/** Скрытый live region карусели (aria-live); стили здесь, т.к. CSS подключается и в списке статей. */
+.content-with-image-gallery .mg-blog-carousel-live {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
 }
 
 /**

--- a/frontend/css/content_image_gallery.css
+++ b/frontend/css/content_image_gallery.css
@@ -16,7 +16,7 @@
 }
 
 .content-with-image-gallery img:not(.mg-blog-carousel-thumb-img):not(.mg-blog-carousel-main-img) {
-    /* Как в редакторе: до 500px по большей стороне, на узком экране — 100% */
+    /* На странице статьи: до 500px по большей стороне, на узком экране — 100% */
     max-width: min(100%, 500px);
     max-height: min(70vh, 500px);
     width: auto;

--- a/frontend/js/entries/blog_content_carousel.js
+++ b/frontend/js/entries/blog_content_carousel.js
@@ -1,0 +1,311 @@
+/**
+ * Карусель фотографий в контенте статей блога (блок .mg-blog-carousel из TinyMCE).
+ * Визуально совпадает с одиночными изображениями: 500px по ширине или высоте, тень, подпись.
+ */
+import Swiper from 'swiper';
+import { Navigation, Thumbs, FreeMode } from 'swiper/modules';
+import 'swiper/css';
+import 'swiper/css/navigation';
+import 'swiper/css/free-mode';
+
+const CAROUSEL_SELECTOR = '.mg-blog-carousel';
+const MIN_SLIDES = 2;
+const CONTENT_IMAGE_SIZE = 500;
+
+const NAV_BTN_BASE = 'swiper-button mg-blog-carousel-nav content-gallery-lightbox-nav';
+/** Те же SVG, что у GLightbox (glightbox-clean .gprev / .gnext). */
+const GLIGHTBOX_PREV_ICON =
+  '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 477.175 477.175" aria-hidden="true"><path d="M145.188,238.575l215.5-215.5c5.3-5.3,5.3-13.8,0-19.1s-13.8-5.3-19.1,0l-225.1,225.1c-5.3,5.3-5.3,13.8,0,19.1l225.1,225c2.6,2.6,6.1,4,9.5,4s6.9-1.3,9.5-4c5.3-5.3,5.3-13.8,0-19.1L145.188,238.575z"/></svg>';
+const GLIGHTBOX_NEXT_ICON =
+  '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 477.175 477.175" aria-hidden="true"><path d="M360.731,229.075l-225.1-225.1c-5.3-5.3-13.8-5.3-19.1,0s-5.3,13.8,0,19.1l215.5,215.5l-215.5,215.5c-5.3,5.3-5.3,13.8,0,19.1c2.6,2.6,6.1,4,9.5,4c3.4,0,6.9-1.3,9.5-4l225.1-225.1C365.931,242.875,365.931,234.275,360.731,229.075z"/></svg>';
+
+const THUMB_SLIDE_CLASS =
+  'swiper-slide mg-blog-carousel-thumb block p-0 appearance-none relative !w-20 !h-14 rounded-md overflow-hidden border border-gray-200 dark:border-neutral-700 bg-gray-100 dark:bg-neutral-800 cursor-pointer opacity-50 transition-opacity duration-200 ease-out [&.swiper-slide-thumb-active]:opacity-100';
+
+/** Как в редакторе: горизонтальные — width 500, вертикальные — height 500. */
+export function applyStandardContentImageSize(img) {
+  const apply = () => {
+    const w = img.naturalWidth;
+    const h = img.naturalHeight;
+    if (!w || !h) return;
+
+    if (h > w) {
+      img.removeAttribute('width');
+      img.setAttribute('height', String(CONTENT_IMAGE_SIZE));
+    } else {
+      img.removeAttribute('height');
+      img.setAttribute('width', String(CONTENT_IMAGE_SIZE));
+    }
+  };
+
+  if (img.complete && img.naturalWidth) {
+    apply();
+  } else {
+    img.addEventListener('load', apply, { once: true });
+  }
+}
+
+function collectImages(carouselEl) {
+  return [...carouselEl.querySelectorAll('img[src]')].filter((img) => {
+    const src = img.src || img.getAttribute('src');
+    return Boolean(src);
+  });
+}
+
+function cloneContentImage(sourceImg) {
+  const slideImg = sourceImg.cloneNode(true);
+  slideImg.removeAttribute('class');
+  slideImg.removeAttribute('style');
+  slideImg.loading = 'lazy';
+  slideImg.decoding = 'async';
+
+  if (!slideImg.hasAttribute('width') && !slideImg.hasAttribute('height')) {
+    slideImg.setAttribute('width', String(CONTENT_IMAGE_SIZE));
+  }
+  applyStandardContentImageSize(slideImg);
+
+  return slideImg;
+}
+
+function buildSlide(sourceImg, galleryId, slideIndex, totalSlides, carouselIndex) {
+  const href = sourceImg.src || sourceImg.getAttribute('src');
+  const slide = document.createElement('div');
+  slide.className = 'swiper-slide mg-blog-carousel-slide shrink-0 w-full';
+  slide.setAttribute('role', 'group');
+  slide.setAttribute('aria-roledescription', 'slide');
+  slide.setAttribute('aria-label', `Слайд ${slideIndex + 1} из ${totalSlides}`);
+
+  const slideBlock = document.createElement('div');
+  slideBlock.className = 'mg-blog-carousel-slide-inner';
+
+  const anchor = document.createElement('a');
+  anchor.href = href;
+  anchor.className = 'glightbox-content block w-full';
+  anchor.setAttribute('data-gallery', galleryId);
+  anchor.setAttribute('data-type', 'image');
+
+  const slideImg = cloneContentImage(sourceImg);
+  slideImg.classList.add('mg-blog-carousel-main-img');
+  anchor.appendChild(slideImg);
+  slideBlock.appendChild(anchor);
+
+  const alt = sourceImg.alt || slideImg.alt || '';
+  if (alt) {
+    const captionId = `mg-blog-carousel-caption-${carouselIndex}-${slideIndex}`;
+    const caption = document.createElement('figcaption');
+    caption.id = captionId;
+    caption.className = 'content-image-caption';
+    caption.textContent = alt;
+    anchor.setAttribute('aria-describedby', captionId);
+    slideImg.setAttribute('aria-describedby', captionId);
+    slideBlock.appendChild(caption);
+  }
+
+  slide.appendChild(slideBlock);
+  return slide;
+}
+
+function buildThumbSlide(sourceImg, slideIndex, totalSlides) {
+  const src = sourceImg.src || sourceImg.getAttribute('src');
+  const alt = sourceImg.alt || `Миниатюра ${slideIndex + 1}`;
+
+  const thumb = document.createElement('button');
+  thumb.type = 'button';
+  thumb.className = THUMB_SLIDE_CLASS;
+  thumb.setAttribute('role', 'tab');
+  thumb.setAttribute('aria-label', `Показать фото ${slideIndex + 1} из ${totalSlides}`);
+  thumb.setAttribute('aria-selected', slideIndex === 0 ? 'true' : 'false');
+
+  const thumbImg = document.createElement('img');
+  thumbImg.src = src;
+  thumbImg.alt = alt;
+  thumbImg.loading = 'lazy';
+  thumbImg.decoding = 'async';
+  thumbImg.className = 'mg-blog-carousel-thumb-img h-full w-full object-cover';
+  thumb.appendChild(thumbImg);
+
+  return thumb;
+}
+
+function syncThumbAriaSelected(thumbsSwiper, activeIndex) {
+  thumbsSwiper?.slides?.forEach((slide, index) => {
+    const tab = slide.querySelector('.mg-blog-carousel-thumb');
+    if (tab) {
+      tab.setAttribute('aria-selected', index === activeIndex ? 'true' : 'false');
+    }
+  });
+}
+
+function announceSlide(swiper, liveRegion, totalSlides) {
+  if (!liveRegion || totalSlides <= 0) return;
+  const index = swiper.activeIndex + 1;
+  liveRegion.textContent = `Фото ${index} из ${totalSlides}`;
+}
+
+function bindCarouselFocusTrap(widget) {
+  widget.addEventListener('keydown', (event) => {
+    if (event.key !== 'Tab') return;
+
+    const focusables = [
+      ...widget.querySelectorAll(
+        'button:not([disabled]), a[href], .mg-blog-carousel-thumb'
+      ),
+    ].filter((el) => el.offsetParent !== null);
+
+    if (focusables.length === 0) return;
+
+    const first = focusables[0];
+    const last = focusables[focusables.length - 1];
+
+    if (event.shiftKey && document.activeElement === first) {
+      event.preventDefault();
+      last.focus();
+    } else if (!event.shiftKey && document.activeElement === last) {
+      event.preventDefault();
+      first.focus();
+    }
+  });
+}
+
+function initBlogCarousel(carouselEl, index) {
+  const images = collectImages(carouselEl);
+  if (images.length < MIN_SLIDES) return;
+
+  const galleryId = `blog-carousel-${index}`;
+  const totalSlides = images.length;
+  const swiperId = `mg-blog-carousel-swiper-${index}`;
+  const thumbsId = `mg-blog-carousel-thumbs-${index}`;
+
+  carouselEl.setAttribute('role', 'region');
+  carouselEl.setAttribute('aria-roledescription', 'карусель');
+  carouselEl.setAttribute('aria-label', 'Галерея фотографий');
+
+  const widget = document.createElement('div');
+  widget.className = 'mg-blog-carousel-widget relative mx-auto w-full max-w-[500px]';
+  widget.setAttribute('tabindex', '0');
+  widget.setAttribute('aria-label', 'Управление каруселью');
+
+  const liveRegion = document.createElement('div');
+  liveRegion.className = 'mg-blog-carousel-live';
+  liveRegion.setAttribute('aria-live', 'polite');
+  liveRegion.setAttribute('aria-atomic', 'true');
+  widget.appendChild(liveRegion);
+
+  const carouselMain = document.createElement('div');
+  carouselMain.className = 'mg-blog-carousel-main relative';
+
+  const swiperRoot = document.createElement('div');
+  swiperRoot.id = swiperId;
+  swiperRoot.className = 'swiper mg-blog-carousel-swiper w-full overflow-hidden';
+  swiperRoot.setAttribute('aria-roledescription', 'carousel');
+  swiperRoot.setAttribute('aria-label', 'Слайды');
+
+  const wrapper = document.createElement('div');
+  wrapper.className = 'swiper-wrapper';
+  images.forEach((img, slideIndex) => {
+    wrapper.appendChild(buildSlide(img, galleryId, slideIndex, totalSlides, index));
+  });
+  swiperRoot.appendChild(wrapper);
+  carouselMain.appendChild(swiperRoot);
+
+  const prevButton = document.createElement('button');
+  prevButton.type = 'button';
+  prevButton.className = `${NAV_BTN_BASE} swiper-button-prev mg-blog-carousel-prev`;
+  prevButton.setAttribute('aria-label', 'Предыдущее фото');
+  prevButton.setAttribute('aria-controls', swiperId);
+  prevButton.innerHTML = GLIGHTBOX_PREV_ICON;
+
+  const nextButton = document.createElement('button');
+  nextButton.type = 'button';
+  nextButton.className = `${NAV_BTN_BASE} swiper-button-next mg-blog-carousel-next`;
+  nextButton.setAttribute('aria-label', 'Следующее фото');
+  nextButton.setAttribute('aria-controls', swiperId);
+  nextButton.innerHTML = GLIGHTBOX_NEXT_ICON;
+
+  carouselMain.appendChild(prevButton);
+  carouselMain.appendChild(nextButton);
+  widget.appendChild(carouselMain);
+
+  const thumbsPanel = document.createElement('div');
+  thumbsPanel.className = 'mg-blog-carousel-thumbs-panel';
+  thumbsPanel.setAttribute('role', 'tablist');
+  thumbsPanel.setAttribute('aria-label', 'Миниатюры фотографий');
+
+  const thumbsRoot = document.createElement('div');
+  thumbsRoot.id = thumbsId;
+  thumbsRoot.className = 'swiper mg-blog-carousel-thumbs';
+
+  const thumbsWrapper = document.createElement('div');
+  thumbsWrapper.className = 'swiper-wrapper';
+  images.forEach((img, slideIndex) => {
+    thumbsWrapper.appendChild(buildThumbSlide(img, slideIndex, totalSlides));
+  });
+  thumbsRoot.appendChild(thumbsWrapper);
+  thumbsPanel.appendChild(thumbsRoot);
+  widget.appendChild(thumbsPanel);
+
+  carouselEl.replaceChildren(widget);
+  carouselEl.classList.add('mg-blog-carousel--initialized');
+  carouselEl.dataset.mgBlogCarouselReady = 'true';
+
+  const thumbsSwiper = new Swiper(thumbsRoot, {
+    modules: [FreeMode],
+    spaceBetween: 8,
+    slidesPerView: 'auto',
+    centerInsufficientSlides: true,
+    freeMode: true,
+    watchSlidesProgress: true,
+  });
+
+  const swiper = new Swiper(swiperRoot, {
+    modules: [Navigation, Thumbs],
+    slidesPerView: 1,
+    spaceBetween: 0,
+    speed: 300,
+    autoHeight: true,
+    watchOverflow: true,
+    navigation: {
+      prevEl: prevButton,
+      nextEl: nextButton,
+    },
+    thumbs: {
+      swiper: thumbsSwiper,
+      multipleActiveThumbs: false,
+    },
+    keyboard: {
+      enabled: true,
+      onlyInViewport: true,
+    },
+  });
+
+  const onSlideChange = () => {
+    announceSlide(swiper, liveRegion, totalSlides);
+    syncThumbAriaSelected(thumbsSwiper, swiper.activeIndex);
+  };
+
+  announceSlide(swiper, liveRegion, totalSlides);
+  swiper.on('slideChange', onSlideChange);
+
+  swiperRoot.querySelectorAll('img').forEach((img) => {
+    const bump = () => swiper.updateAutoHeight(swiper.params.speed ?? 300);
+    if (img.complete) {
+      bump();
+    } else {
+      img.addEventListener('load', bump, { once: true });
+    }
+  });
+
+  bindCarouselFocusTrap(widget);
+}
+
+export function initBlogContentCarousels(root = document) {
+  const containers = root.querySelectorAll('.content-with-image-gallery');
+  let carouselIndex = 0;
+
+  containers.forEach((container) => {
+    container.querySelectorAll(CAROUSEL_SELECTOR).forEach((carouselEl) => {
+      if (carouselEl.dataset.mgBlogCarouselReady === 'true') return;
+      initBlogCarousel(carouselEl, carouselIndex++);
+    });
+  });
+}

--- a/frontend/js/entries/blog_content_carousel.js
+++ b/frontend/js/entries/blog_content_carousel.js
@@ -22,7 +22,7 @@ const GLIGHTBOX_NEXT_ICON =
 const THUMB_SLIDE_CLASS =
   'swiper-slide mg-blog-carousel-thumb block p-0 appearance-none relative !w-20 !h-14 rounded-md overflow-hidden border border-gray-200 dark:border-neutral-700 bg-gray-100 dark:bg-neutral-800 cursor-pointer opacity-50 transition-opacity duration-200 ease-out [&.swiper-slide-thumb-active]:opacity-100';
 
-/** Как в редакторе: горизонтальные — width 500, вертикальные — height 500. */
+/** На странице статьи: горизонтальные — width 500, вертикальные — height 500. */
 export function applyStandardContentImageSize(img) {
   const apply = () => {
     const w = img.naturalWidth;

--- a/frontend/js/entries/blog_content_carousel.js
+++ b/frontend/js/entries/blog_content_carousel.js
@@ -244,8 +244,12 @@ function initBlogCarousel(carouselEl, index) {
   thumbsPanel.appendChild(thumbsRoot);
   widget.appendChild(thumbsPanel);
 
+  const reservedHeight = carouselEl.offsetHeight;
+  if (reservedHeight > 0) {
+    carouselEl.style.setProperty('--mg-blog-carousel-min-height', `${reservedHeight}px`);
+  }
+  carouselEl.classList.add('mg-blog-carousel--initializing');
   carouselEl.replaceChildren(widget);
-  carouselEl.classList.add('mg-blog-carousel--initialized');
   carouselEl.dataset.mgBlogCarouselReady = 'true';
 
   const thumbsSwiper = new Swiper(thumbsRoot, {
@@ -285,6 +289,10 @@ function initBlogCarousel(carouselEl, index) {
 
   announceSlide(swiper, liveRegion, totalSlides);
   swiper.on('slideChange', onSlideChange);
+
+  carouselEl.classList.remove('mg-blog-carousel--initializing');
+  carouselEl.classList.add('mg-blog-carousel--initialized');
+  carouselEl.style.removeProperty('--mg-blog-carousel-min-height');
 
   swiperRoot.querySelectorAll('img').forEach((img) => {
     const bump = () => swiper.updateAutoHeight(swiper.params.speed ?? 300);

--- a/frontend/js/entries/blog_content_carousel.test.js
+++ b/frontend/js/entries/blog_content_carousel.test.js
@@ -1,0 +1,202 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const swiperInstances = [];
+
+vi.mock('swiper', () => ({
+  default: class MockSwiper {
+    constructor(rootEl, options) {
+      this.rootEl = rootEl;
+      this.options = options;
+      this.activeIndex = 0;
+      this.params = { speed: 300 };
+      this.slides = [];
+      this._handlers = {};
+      swiperInstances.push(this);
+    }
+
+    on(event, handler) {
+      this._handlers[event] = handler;
+    }
+
+    updateAutoHeight() {}
+
+    emit(event) {
+      this._handlers[event]?.();
+    }
+  },
+}));
+
+vi.mock('swiper/modules', () => ({
+  Navigation: {},
+  Thumbs: {},
+  FreeMode: {},
+}));
+
+vi.mock('swiper/css', () => ({}));
+vi.mock('swiper/css/navigation', () => ({}));
+vi.mock('swiper/css/free-mode', () => ({}));
+
+import {
+  applyStandardContentImageSize,
+  initBlogContentCarousels,
+} from './blog_content_carousel.js';
+
+function buildCarouselHtml(urls, alt = '') {
+  const altAttr = alt ? ` alt="${alt}"` : '';
+  const captionAttr = alt ? ` data-mg-caption="${alt}"` : '';
+  const imgs = urls
+    .map((url) => `<img src="${url}" width="200"${altAttr}>`)
+    .join('');
+  return `<div class="mg-blog-carousel" data-mg-blog-carousel${captionAttr}>${imgs}</div>`;
+}
+
+describe('applyStandardContentImageSize', () => {
+  it('ставит height=500 для вертикального изображения', () => {
+    const img = document.createElement('img');
+    Object.defineProperty(img, 'naturalWidth', { value: 400, configurable: true });
+    Object.defineProperty(img, 'naturalHeight', { value: 800, configurable: true });
+    Object.defineProperty(img, 'complete', { value: true, configurable: true });
+
+    applyStandardContentImageSize(img);
+
+    expect(img.getAttribute('height')).toBe('500');
+    expect(img.hasAttribute('width')).toBe(false);
+  });
+
+  it('ставит width=500 для горизонтального изображения', () => {
+    const img = document.createElement('img');
+    Object.defineProperty(img, 'naturalWidth', { value: 1200, configurable: true });
+    Object.defineProperty(img, 'naturalHeight', { value: 600, configurable: true });
+    Object.defineProperty(img, 'complete', { value: true, configurable: true });
+
+    applyStandardContentImageSize(img);
+
+    expect(img.getAttribute('width')).toBe('500');
+    expect(img.hasAttribute('height')).toBe(false);
+  });
+
+  it('ждёт load, если naturalWidth ещё нет', () => {
+    const img = document.createElement('img');
+    Object.defineProperty(img, 'complete', { value: false, configurable: true });
+    Object.defineProperty(img, 'naturalWidth', { value: 0, configurable: true });
+    Object.defineProperty(img, 'naturalHeight', { value: 0, configurable: true });
+
+    applyStandardContentImageSize(img);
+
+    Object.defineProperty(img, 'naturalWidth', { value: 1000, configurable: true });
+    Object.defineProperty(img, 'naturalHeight', { value: 500, configurable: true });
+    img.dispatchEvent(new Event('load'));
+
+    expect(img.getAttribute('width')).toBe('500');
+  });
+});
+
+describe('initBlogContentCarousels', () => {
+  let container;
+
+  beforeEach(() => {
+    swiperInstances.length = 0;
+    document.body.innerHTML = '';
+    container = document.createElement('div');
+    container.className = 'content-with-image-gallery';
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('не инициализирует карусель с одним изображением', () => {
+    container.innerHTML = buildCarouselHtml(['/media/a.jpg']);
+    initBlogContentCarousels();
+    expect(container.querySelector('.mg-blog-carousel-widget')).toBeNull();
+    expect(swiperInstances).toHaveLength(0);
+  });
+
+  it('строит виджет Swiper и glightbox-ссылки для двух и более фото', () => {
+    container.innerHTML = buildCarouselHtml(
+      ['/media/a.jpg', '/media/b.jpg'],
+      'Подпись',
+    );
+    initBlogContentCarousels();
+
+    const carousel = container.querySelector('.mg-blog-carousel');
+    expect(carousel.dataset.mgBlogCarouselReady).toBe('true');
+    expect(carousel.classList.contains('mg-blog-carousel--initialized')).toBe(true);
+
+    const widget = carousel.querySelector('.mg-blog-carousel-widget');
+    expect(widget).not.toBeNull();
+    expect(widget.getAttribute('tabindex')).toBe('0');
+
+    const mainLinks = carousel.querySelectorAll('.mg-blog-carousel-main .glightbox-content');
+    expect(mainLinks).toHaveLength(2);
+    expect(mainLinks[0].href).toContain('/media/a.jpg');
+    expect(mainLinks[0].getAttribute('data-gallery')).toBe('blog-carousel-0');
+
+    const caption = carousel.querySelector('.content-image-caption');
+    expect(caption?.textContent).toBe('Подпись');
+
+    expect(swiperInstances).toHaveLength(2);
+    const mainSwiper = swiperInstances[1];
+    expect(mainSwiper.options.navigation).toBeDefined();
+    expect(mainSwiper.options.thumbs).toBeDefined();
+  });
+
+  it('не переинициализирует уже готовую карусель', () => {
+    container.innerHTML = buildCarouselHtml(['/media/a.jpg', '/media/b.jpg']);
+    initBlogContentCarousels();
+    const firstWidget = container.querySelector('.mg-blog-carousel-widget');
+    swiperInstances.length = 0;
+
+    initBlogContentCarousels();
+
+    expect(container.querySelector('.mg-blog-carousel-widget')).toBe(firstWidget);
+    expect(swiperInstances).toHaveLength(0);
+  });
+
+  it('объявляет смену слайда в live region', () => {
+    container.innerHTML = buildCarouselHtml(['/media/a.jpg', '/media/b.jpg', '/media/c.jpg']);
+    initBlogContentCarousels();
+
+    const live = container.querySelector('.mg-blog-carousel-live');
+    expect(live?.textContent).toMatch(/Фото 1 из 3/);
+
+    const mainSwiper = swiperInstances[1];
+    mainSwiper.activeIndex = 1;
+    mainSwiper.emit('slideChange');
+    expect(live?.textContent).toBe('Фото 2 из 3');
+  });
+
+  it('синхронизирует aria-selected у миниатюр', () => {
+    container.innerHTML = buildCarouselHtml(['/media/a.jpg', '/media/b.jpg']);
+    initBlogContentCarousels();
+
+    const thumbs = [...container.querySelectorAll('.mg-blog-carousel-thumb')];
+    expect(thumbs[0].getAttribute('aria-selected')).toBe('true');
+    expect(thumbs[1].getAttribute('aria-selected')).toBe('false');
+
+    const mainSwiper = swiperInstances[1];
+    const thumbsSwiper = swiperInstances[0];
+    thumbsSwiper.slides = thumbs.map((tab) => {
+      const slide = document.createElement('div');
+      slide.appendChild(tab);
+      return slide;
+    });
+
+    mainSwiper.activeIndex = 1;
+    mainSwiper.emit('slideChange');
+
+    expect(thumbs[0].getAttribute('aria-selected')).toBe('false');
+    expect(thumbs[1].getAttribute('aria-selected')).toBe('true');
+  });
+
+  it('создаёт панель миниатюр с role=tablist и aria-label', () => {
+    container.innerHTML = buildCarouselHtml(['/media/a.jpg', '/media/b.jpg']);
+    initBlogContentCarousels();
+
+    const thumbsPanel = container.querySelector('.mg-blog-carousel-thumbs-panel');
+    expect(thumbsPanel?.getAttribute('role')).toBe('tablist');
+    expect(thumbsPanel?.getAttribute('aria-label')).toBe('Миниатюры фотографий');
+    expect(container.querySelectorAll('.mg-blog-carousel-thumb[role="tab"]')).toHaveLength(2);
+  });
+});

--- a/frontend/js/entries/content_image_gallery.js
+++ b/frontend/js/entries/content_image_gallery.js
@@ -4,7 +4,10 @@
  * Изображения внутри .mg-blog-carousel обрабатываются в blog_content_carousel.js.
  */
 import GLightbox from 'glightbox';
-import { initBlogContentCarousels } from './blog_content_carousel.js';
+import {
+  applyStandardContentImageSize,
+  initBlogContentCarousels,
+} from './blog_content_carousel.js';
 
 function isStandaloneContentImage(img) {
   if (img.closest('.mg-blog-carousel')) return false;
@@ -25,6 +28,8 @@ function initStandaloneImageLightbox() {
     images.forEach((img) => {
       const href = img.src || img.getAttribute('src');
       if (!href) return;
+
+      applyStandardContentImageSize(img);
 
       const anchor = document.createElement('a');
       anchor.href = href;

--- a/frontend/js/entries/content_image_gallery.js
+++ b/frontend/js/entries/content_image_gallery.js
@@ -12,9 +12,7 @@ function isStandaloneContentImage(img) {
   return true;
 }
 
-function initContentImageGallery() {
-  initBlogContentCarousels();
-
+function initStandaloneImageLightbox() {
   const containers = document.querySelectorAll('.content-with-image-gallery');
   if (containers.length === 0) return;
 
@@ -54,9 +52,17 @@ function initContentImageGallery() {
   });
 }
 
+function bootContentImageGallery() {
+  initBlogContentCarousels();
+  initStandaloneImageLightbox();
+}
+
+/** Карусели — сразу при загрузке модуля, чтобы не мелькали все фото. */
+initBlogContentCarousels();
+
 if (document.readyState === 'loading') {
-  document.addEventListener('DOMContentLoaded', initContentImageGallery);
+  document.addEventListener('DOMContentLoaded', bootContentImageGallery);
 } else {
-  initContentImageGallery();
+  bootContentImageGallery();
 }
 

--- a/frontend/js/entries/content_image_gallery.js
+++ b/frontend/js/entries/content_image_gallery.js
@@ -1,16 +1,26 @@
 /**
  * Галерея изображений для контента статей и новостей.
  * При клике на изображение открывается лайтбокс GLightbox для просмотра в полном размере.
+ * Изображения внутри .mg-blog-carousel обрабатываются в blog_content_carousel.js.
  */
 import GLightbox from 'glightbox';
+import { initBlogContentCarousels } from './blog_content_carousel.js';
+
+function isStandaloneContentImage(img) {
+  if (img.closest('.mg-blog-carousel')) return false;
+  if (img.closest('.glightbox-content')) return false;
+  return true;
+}
 
 function initContentImageGallery() {
+  initBlogContentCarousels();
+
   const containers = document.querySelectorAll('.content-with-image-gallery');
   if (containers.length === 0) return;
 
   let galleryIndex = 0;
   containers.forEach((container) => {
-    const images = container.querySelectorAll('img[src]');
+    const images = [...container.querySelectorAll('img[src]')].filter(isStandaloneContentImage);
     if (images.length === 0) return;
 
     const galleryId = `content-gallery-${galleryIndex++}`;

--- a/frontend/js/entries/content_image_gallery.test.js
+++ b/frontend/js/entries/content_image_gallery.test.js
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const initBlogContentCarousels = vi.fn();
+const applyStandardContentImageSize = vi.fn((img) => {
+  img.setAttribute('data-sized', 'true');
+});
+const glightboxMock = vi.fn();
+
+vi.mock('./blog_content_carousel.js', () => ({
+  initBlogContentCarousels,
+  applyStandardContentImageSize,
+}));
+
+vi.mock('glightbox', () => ({
+  default: glightboxMock,
+}));
+
+describe('content_image_gallery', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    document.body.innerHTML = '';
+    Object.defineProperty(document, 'readyState', {
+      value: 'complete',
+      configurable: true,
+    });
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  async function loadGalleryModule() {
+    await import('./content_image_gallery.js');
+  }
+
+  it('инициализирует карусели при загрузке модуля', async () => {
+    await loadGalleryModule();
+    expect(initBlogContentCarousels).toHaveBeenCalled();
+  });
+
+  it('оборачивает одиночные изображения в glightbox и добавляет подпись', async () => {
+    const container = document.createElement('div');
+    container.className = 'content-with-image-gallery';
+    container.innerHTML =
+      '<p><img src="/media/photo.jpg" alt="Вид на город"></p>';
+    document.body.appendChild(container);
+
+    await loadGalleryModule();
+
+    const anchor = container.querySelector('a.glightbox-content');
+    expect(anchor).not.toBeNull();
+    expect(anchor.href).toContain('/media/photo.jpg');
+    expect(anchor.getAttribute('data-gallery')).toBe('content-gallery-0');
+    expect(anchor.querySelector('img')).not.toBeNull();
+    expect(applyStandardContentImageSize).toHaveBeenCalled();
+
+    const caption = container.querySelector('.content-image-caption');
+    expect(caption?.textContent).toBe('Вид на город');
+
+    expect(glightboxMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        selector: '.content-with-image-gallery .glightbox-content',
+        loop: true,
+      }),
+    );
+  });
+
+  it('не оборачивает изображения внутри карусели', async () => {
+    const container = document.createElement('div');
+    container.className = 'content-with-image-gallery';
+    container.innerHTML = `
+      <div class="mg-blog-carousel">
+        <img src="/media/c1.jpg" alt="c1">
+        <img src="/media/c2.jpg" alt="c2">
+      </div>
+      <p><img src="/media/alone.jpg" alt="solo"></p>
+    `;
+    document.body.appendChild(container);
+
+    await loadGalleryModule();
+
+    const carousel = container.querySelector('.mg-blog-carousel');
+    expect(carousel.querySelector('a.glightbox-content')).toBeNull();
+
+    const standaloneAnchor = container.querySelector('p a.glightbox-content');
+    expect(standaloneAnchor).not.toBeNull();
+    expect(standaloneAnchor.querySelector('img')?.getAttribute('src')).toContain('/media/alone.jpg');
+  });
+
+  it('не оборачивает изображения, уже внутри glightbox-content', async () => {
+    const container = document.createElement('div');
+    container.className = 'content-with-image-gallery';
+    container.innerHTML = `
+      <a class="glightbox-content" href="/media/x.jpg">
+        <img src="/media/x.jpg" alt="x">
+      </a>
+    `;
+    document.body.appendChild(container);
+
+    await loadGalleryModule();
+
+    expect(container.querySelectorAll('a.glightbox-content')).toHaveLength(1);
+  });
+
+  it('не вызывает GLightbox, если на странице нет контейнера галереи', async () => {
+    document.body.innerHTML = '<p>Только текст</p>';
+    await loadGalleryModule();
+    expect(glightboxMock).not.toHaveBeenCalled();
+  });
+
+  it('инициализирует GLightbox при контейнере даже без изображений', async () => {
+    const container = document.createElement('div');
+    container.className = 'content-with-image-gallery';
+    container.innerHTML = '<p>Только текст</p>';
+    document.body.appendChild(container);
+
+    await loadGalleryModule();
+
+    expect(glightboxMock).toHaveBeenCalled();
+  });
+});

--- a/frontend/js/test/tinymce-helpers.js
+++ b/frontend/js/test/tinymce-helpers.js
@@ -1,0 +1,168 @@
+import { vi } from 'vitest';
+
+/**
+ * Минимальный mock TinyMCE editor для тестов плагинов в static/tinymce/js.
+ * @returns {{
+ *   getBody: () => HTMLElement,
+ *   dom: object,
+ *   selection: object,
+ *   windowManager: object,
+ *   undoManager: object,
+ *   ui: object,
+ *   onHandlers: Map<string, Function[]>,
+ *   insertContent: ReturnType<typeof vi.fn>,
+ *   options: object,
+ *   settings: object,
+ *   trigger: (event: string, payload?: object) => void,
+ * }}
+ */
+export function createMockTinyMCEEditor(initialBodyHtml = '') {
+  const body = document.createElement('div');
+  body.innerHTML = initialBodyHtml;
+
+  const onHandlers = new Map();
+
+  function on(event, handler) {
+    const list = onHandlers.get(event) || [];
+    list.push(handler);
+    onHandlers.set(event, list);
+  }
+
+  function trigger(event, payload = {}) {
+    const list = onHandlers.get(event) || [];
+    list.forEach((handler) => handler(payload));
+  }
+
+  const insertContent = vi.fn();
+
+  const dom = {
+    hasClass(node, className) {
+      return Boolean(node?.classList?.contains(className));
+    },
+    getParent(node, selector) {
+      if (!node) return null;
+      if (selector.startsWith('.')) {
+        const cls = selector.slice(1);
+        let cur = node;
+        while (cur) {
+          if (cur.nodeType === 1 && cur.classList?.contains(cls)) return cur;
+          cur = cur.parentNode;
+        }
+        return null;
+      }
+      return node.closest?.(selector) ?? null;
+    },
+    setAttrib(node, name, value) {
+      if (!node) return;
+      if (value === null || value === undefined) {
+        node.removeAttribute(name);
+      } else {
+        node.setAttribute(name, value);
+      }
+    },
+    setStyle(node, prop, value) {
+      if (!node?.style) return;
+      if (value === null || value === undefined) {
+        node.style.removeProperty(prop);
+      } else {
+        node.style[prop] = value;
+      }
+    },
+    setOuterHTML: vi.fn((node, html) => {
+      if (!node?.parentNode) return;
+      const tpl = document.createElement('template');
+      tpl.innerHTML = html;
+      const replacement = tpl.content.firstChild;
+      if (replacement) {
+        node.parentNode.replaceChild(replacement, node);
+      }
+    }),
+    create(tag) {
+      return document.createElement(tag);
+    },
+    insertBefore(newNode, ref) {
+      ref.parentNode?.insertBefore(newNode, ref);
+    },
+    insertAfter(newNode, ref) {
+      ref.parentNode?.insertBefore(newNode, ref.nextSibling);
+    },
+    remove(node) {
+      node?.parentNode?.removeChild(node);
+    },
+  };
+
+  let lastDialogConfig = null;
+  const windowManager = {
+    open(config) {
+      lastDialogConfig = config;
+      config.onOpen?.();
+      return { close: vi.fn() };
+    },
+    alert: vi.fn(),
+    getLastDialogConfig() {
+      return lastDialogConfig;
+    },
+  };
+
+  const editor = {
+    getBody: () => body,
+    dom,
+    selection: {
+      getNode: () => body.querySelector('img, .mg-blog-carousel') || body.firstChild,
+    },
+    windowManager,
+    undoManager: {
+      transact(fn) {
+        fn();
+      },
+    },
+    ui: {
+      registry: {
+        addButton: vi.fn(),
+        addContextToolbar: vi.fn(),
+      },
+    },
+    on,
+    insertContent,
+    nodeChanged: vi.fn(),
+    options: {
+      set: vi.fn(),
+    },
+    settings: {},
+    translate(key) {
+      return key;
+    },
+    trigger,
+    _test: { body, onHandlers, getLastDialogConfig: () => lastDialogConfig },
+  };
+
+  return editor;
+}
+
+/**
+ * @param {File[]} files
+ */
+export function createFileList(files) {
+  const list = {
+    length: files.length,
+    item(i) {
+      return files[i] ?? null;
+    },
+  };
+  files.forEach((file, i) => {
+    list[i] = file;
+  });
+  return list;
+}
+
+/**
+ * @param {string} name
+ * @param {number} [size]
+ * @param {number} [lastModified]
+ */
+export function createMockFile(name, size = 100, lastModified = 1) {
+  return new File(['x'.repeat(size)], name, {
+    type: 'image/jpeg',
+    lastModified,
+  });
+}

--- a/frontend/js/tinymce/tinymce_blog_carousel_multiselect.test.js
+++ b/frontend/js/tinymce/tinymce_blog_carousel_multiselect.test.js
@@ -1,0 +1,405 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  createMockTinyMCEEditor,
+  createFileList,
+  createMockFile,
+} from '../test/tinymce-helpers.js';
+
+describe('tinymce_blog_carousel_multiselect', () => {
+  /** @type {ReturnType<typeof createMockTinyMCEEditor>} */
+  let editor;
+  let blogCarouselButton;
+  let blogCarouselEditButton;
+  let contextToolbarConfig;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    vi.useFakeTimers();
+    document.body.innerHTML = '';
+    delete window.djangoTinyMCESetupBlogCarousel;
+    window.djangoTinyMCEUploadImageFile = vi.fn();
+
+    await import('@static/tinymce/js/tinymce_blog_carousel_multiselect.js');
+
+    editor = createMockTinyMCEEditor('');
+    window.djangoTinyMCESetupBlogCarousel(editor);
+
+    const addButton = editor.ui.registry.addButton;
+    blogCarouselButton = addButton.mock.calls.find((c) => c[0] === 'blog_carousel')?.[1];
+    blogCarouselEditButton = addButton.mock.calls.find((c) => c[0] === 'blog_carousel_edit')?.[1];
+    contextToolbarConfig = editor.ui.registry.addContextToolbar.mock.calls[0]?.[1];
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    delete window.djangoTinyMCESetupBlogCarousel;
+    delete window.djangoTinyMCEUploadImageFile;
+  });
+
+  function openNewCarouselDialog() {
+    blogCarouselButton.onAction();
+    return editor._test.getLastDialogConfig();
+  }
+
+  function getDialogPanels(dialogConfig) {
+    return dialogConfig.body.items.filter((item) => item.type === 'htmlpanel');
+  }
+
+  function initDropzonePanel(dialogConfig) {
+    const dropzonePanel = getDialogPanels(dialogConfig).find((p) =>
+      p.html.includes('data-mg-carousel-dropzone'),
+    );
+    const panelEl = document.createElement('div');
+    panelEl.innerHTML = dropzonePanel.html;
+    document.body.appendChild(panelEl);
+    dropzonePanel.onInit(panelEl);
+    return panelEl;
+  }
+
+  function initExistingSlidesPanel(dialogConfig, urls) {
+    const existingPanel = getDialogPanels(dialogConfig).find((p) =>
+      p.html.includes('data-mg-existing-slides'),
+    );
+    if (!existingPanel) return null;
+    const panelEl = document.createElement('div');
+    panelEl.innerHTML = existingPanel.html;
+    document.body.appendChild(panelEl);
+    existingPanel.onInit(panelEl);
+    return panelEl;
+  }
+
+  function submitDialog(dialogConfig, apiOverrides = {}) {
+    const api = {
+      getData: () => ({ alt: '' }),
+      block: vi.fn(),
+      unblock: vi.fn(),
+      close: vi.fn(),
+      ...apiOverrides,
+    };
+    dialogConfig.onSubmit(api);
+    return api;
+  }
+
+  it('регистрирует кнопки и контекстный тулбар', () => {
+    expect(typeof window.djangoTinyMCESetupBlogCarousel).toBe('function');
+    expect(blogCarouselButton).toBeDefined();
+    expect(blogCarouselEditButton).toBeDefined();
+    expect(contextToolbarConfig.items).toBe('blog_carousel_edit');
+  });
+
+  it('вставляет карусель с экранированием alt и URL', async () => {
+    const dialog = openNewCarouselDialog();
+    const panel = initDropzonePanel(dialog);
+    const input = panel.querySelector('[data-mg-carousel-input]');
+
+    const files = createFileList([
+      createMockFile('a.jpg', 10, 1),
+      createMockFile('b.jpg', 10, 2),
+    ]);
+    Object.defineProperty(input, 'files', { value: files, configurable: true });
+    input.dispatchEvent(new Event('change'));
+
+    window.djangoTinyMCEUploadImageFile.mockImplementation(() =>
+      Promise.resolve('/media/"unsafe>.jpg'),
+    );
+
+    const api = submitDialog(dialog, {
+      getData: () => ({ alt: 'Подпись <script>' }),
+    });
+
+    await vi.waitFor(() => {
+      expect(api.close).toHaveBeenCalled();
+    });
+
+    const html = editor.insertContent.mock.calls[0][0];
+    expect(html).toContain('class="mg-blog-carousel"');
+    expect(html).toContain('data-mg-caption="Подпись &lt;script>"');
+    expect(html).toContain('src="/media/&quot;unsafe>.jpg"');
+    expect(html).toContain('width="200"');
+    expect((html.match(/<img/g) || []).length).toBe(2);
+  });
+
+  it('принимает файлы, перетащенные в dropzone', async () => {
+    const dialog = openNewCarouselDialog();
+    const panel = initDropzonePanel(dialog);
+    const dropzone = panel.querySelector('[data-mg-carousel-dropzone]');
+
+    const files = createFileList([
+      createMockFile('drop-a.jpg', 10, 1),
+      createMockFile('drop-b.jpg', 10, 2),
+    ]);
+    dropzone.dispatchEvent(
+      Object.assign(new Event('drop', { bubbles: true }), {
+        dataTransfer: { files },
+        preventDefault: vi.fn(),
+      }),
+    );
+
+    window.djangoTinyMCEUploadImageFile.mockResolvedValue('/media/drop.jpg');
+    const api = submitDialog(dialog);
+    await vi.waitFor(() => expect(api.close).toHaveBeenCalled());
+    expect(editor.insertContent).toHaveBeenCalled();
+  });
+
+  it('требует минимум 2 изображения', () => {
+    const dialog = openNewCarouselDialog();
+    initDropzonePanel(dialog);
+    submitDialog(dialog);
+    expect(editor.windowManager.alert).toHaveBeenCalledWith(
+      'В карусели должно быть минимум 2 изображения.',
+    );
+    expect(editor.insertContent).not.toHaveBeenCalled();
+  });
+
+  it('предупреждает при превышении лимита новых файлов', async () => {
+    const dialog = openNewCarouselDialog();
+    const panel = initDropzonePanel(dialog);
+    const input = panel.querySelector('[data-mg-carousel-input]');
+
+    const many = Array.from({ length: 12 }, (_, i) =>
+      createMockFile(`f${i}.jpg`, 10, i + 1),
+    );
+    Object.defineProperty(input, 'files', { value: createFileList(many), configurable: true });
+    input.dispatchEvent(new Event('change'));
+
+    window.djangoTinyMCEUploadImageFile.mockResolvedValue('/media/x.jpg');
+
+    submitDialog(dialog);
+    await vi.waitFor(() => {
+      expect(editor.windowManager.alert).toHaveBeenCalledWith(
+        expect.stringContaining('больше 10 новых файлов'),
+      );
+    });
+  });
+
+  it('дедуплицирует одинаковые файлы при повторном выборе', async () => {
+    const dialog = openNewCarouselDialog();
+    const panel = initDropzonePanel(dialog);
+    const input = panel.querySelector('[data-mg-carousel-input]');
+    const fileA = createMockFile('dup.jpg', 50, 99);
+    const fileB = createMockFile('other.jpg', 50, 100);
+
+    Object.defineProperty(input, 'files', {
+      value: createFileList([fileA, fileB]),
+      configurable: true,
+    });
+    input.dispatchEvent(new Event('change'));
+
+    Object.defineProperty(input, 'files', {
+      value: createFileList([fileA]),
+      configurable: true,
+    });
+    input.dispatchEvent(new Event('change'));
+
+    window.djangoTinyMCEUploadImageFile
+      .mockResolvedValueOnce('/media/1.jpg')
+      .mockResolvedValueOnce('/media/2.jpg');
+
+    const api = submitDialog(dialog);
+    await vi.waitFor(() => expect(api.close).toHaveBeenCalled());
+
+    expect(window.djangoTinyMCEUploadImageFile).toHaveBeenCalledTimes(2);
+  });
+
+  it('загружает файлы с ограниченной параллельностью и сохраняет порядок', async () => {
+    const dialog = openNewCarouselDialog();
+    const panel = initDropzonePanel(dialog);
+    const input = panel.querySelector('[data-mg-carousel-input]');
+
+    const files = createFileList([
+      createMockFile('1.jpg', 10, 1),
+      createMockFile('2.jpg', 10, 2),
+      createMockFile('3.jpg', 10, 3),
+      createMockFile('4.jpg', 10, 4),
+    ]);
+    Object.defineProperty(input, 'files', { value: files, configurable: true });
+    input.dispatchEvent(new Event('change'));
+
+    let active = 0;
+    let maxActive = 0;
+    const order = [];
+
+    window.djangoTinyMCEUploadImageFile.mockImplementation((file) => {
+      active += 1;
+      maxActive = Math.max(maxActive, active);
+      return new Promise((resolve) => {
+        setTimeout(() => {
+          order.push(file.name);
+          active -= 1;
+          resolve(`/media/${file.name}`);
+        }, 10);
+      });
+    });
+
+    const api = submitDialog(dialog);
+    await vi.runAllTimersAsync();
+    await vi.waitFor(() => expect(api.close).toHaveBeenCalled());
+
+    expect(maxActive).toBeLessThanOrEqual(3);
+    expect(order).toEqual(['1.jpg', '2.jpg', '3.jpg', '4.jpg']);
+
+    const html = editor.insertContent.mock.calls[0][0];
+    expect(html.indexOf('/media/1.jpg')).toBeLessThan(html.indexOf('/media/4.jpg'));
+  });
+
+  it('не сохраняет карусель, если после удаления осталось меньше 2 фото', () => {
+    editor._test.body.innerHTML = `
+      <div class="mg-blog-carousel" data-mg-caption="Старая">
+        <img src="/media/a.jpg" alt="Старая">
+        <img src="/media/b.jpg" alt="Старая">
+      </div>
+    `;
+    editor.selection.getNode = () => editor._test.body.querySelector('.mg-blog-carousel');
+
+    blogCarouselEditButton.onAction();
+    const dialog = editor._test.getLastDialogConfig();
+    const existingPanel = initExistingSlidesPanel(dialog);
+
+    existingPanel.querySelector('[data-mg-remove-slide]').click();
+
+    const api = submitDialog(dialog, { getData: () => ({ alt: 'Новая' }) });
+    expect(editor.windowManager.alert).toHaveBeenCalledWith(
+      'В карусели должно быть минимум 2 изображения.',
+    );
+    expect(api.close).not.toHaveBeenCalled();
+  });
+
+  it('сохраняет карусель при редактировании с удалением и новыми файлами', async () => {
+    editor._test.body.innerHTML = `
+      <div class="mg-blog-carousel" data-mg-caption="Cap">
+        <img src="/media/old1.jpg">
+        <img src="/media/old2.jpg">
+        <img src="/media/old3.jpg">
+      </div>
+    `;
+    const carousel = editor._test.body.querySelector('.mg-blog-carousel');
+    editor.selection.getNode = () => carousel;
+
+    blogCarouselEditButton.onAction();
+    const dialog = editor._test.getLastDialogConfig();
+    const existingPanel = initExistingSlidesPanel(dialog);
+    existingPanel.querySelector('[data-mg-remove-slide]').click();
+
+    const dropzone = initDropzonePanel(dialog);
+    const input = dropzone.querySelector('[data-mg-carousel-input]');
+    Object.defineProperty(input, 'files', {
+      value: createFileList([createMockFile('n1.jpg'), createMockFile('n2.jpg')]),
+      configurable: true,
+    });
+    input.dispatchEvent(new Event('change'));
+
+    window.djangoTinyMCEUploadImageFile
+      .mockResolvedValueOnce('/media/n1.jpg')
+      .mockResolvedValueOnce('/media/n2.jpg');
+
+    submitDialog(dialog, { getData: () => ({ alt: 'Cap' }) });
+    await vi.waitFor(() => {
+      expect(editor.dom.setOuterHTML).toHaveBeenCalled();
+    });
+
+    const html = editor.dom.setOuterHTML.mock.calls[0][1];
+    expect(html).toContain('/media/old2.jpg');
+    expect(html).toContain('/media/old3.jpg');
+    expect(html).toContain('/media/n1.jpg');
+    expect(html).not.toContain('/media/old1.jpg');
+  });
+
+  it('показывает ошибку при сбое загрузки', async () => {
+    const dialog = openNewCarouselDialog();
+    const panel = initDropzonePanel(dialog);
+    const input = panel.querySelector('[data-mg-carousel-input]');
+    Object.defineProperty(input, 'files', {
+      value: createFileList([createMockFile('a.jpg'), createMockFile('b.jpg')]),
+      configurable: true,
+    });
+    input.dispatchEvent(new Event('change'));
+
+    window.djangoTinyMCEUploadImageFile.mockRejectedValue(new Error('Сеть недоступна'));
+
+    const api = submitDialog(dialog);
+    await vi.waitFor(() => {
+      expect(editor.windowManager.alert).toHaveBeenCalledWith('Сеть недоступна');
+    });
+    expect(api.unblock).toHaveBeenCalled();
+    expect(api.close).not.toHaveBeenCalled();
+  });
+
+  it('отклоняет загрузку, если djangoTinyMCEUploadImageFile недоступен', async () => {
+    delete window.djangoTinyMCEUploadImageFile;
+    const dialog = openNewCarouselDialog();
+    const panel = initDropzonePanel(dialog);
+    const input = panel.querySelector('[data-mg-carousel-input]');
+    Object.defineProperty(input, 'files', {
+      value: createFileList([createMockFile('a.jpg'), createMockFile('b.jpg')]),
+      configurable: true,
+    });
+    input.dispatchEvent(new Event('change'));
+
+    const api = submitDialog(dialog);
+    await vi.waitFor(() => {
+      expect(editor.windowManager.alert).toHaveBeenCalledWith(
+        'Загрузка изображений недоступна',
+      );
+    });
+    expect(api.unblock).toHaveBeenCalled();
+  });
+
+  it('открывает редактирование по двойному клику', () => {
+    editor._test.body.innerHTML = `
+      <div class="mg-blog-carousel">
+        <img src="/media/a.jpg"><img src="/media/b.jpg">
+      </div>
+    `;
+    const img = editor._test.body.querySelector('img');
+    const handlers = editor._test.onHandlers.get('dblclick') || [];
+    const evt = { target: img, preventDefault: vi.fn() };
+    handlers[0](evt);
+
+    expect(evt.preventDefault).toHaveBeenCalled();
+    expect(editor._test.getLastDialogConfig().title).toBe('Изменить карусель');
+  });
+
+  it('контекстный тулбар активен только на карусели', () => {
+    const carousel = document.createElement('div');
+    carousel.className = 'mg-blog-carousel';
+    expect(contextToolbarConfig.predicate(carousel)).toBe(true);
+    expect(contextToolbarConfig.predicate(document.createElement('p'))).toBe(false);
+  });
+
+  it('парсит alt из data-mg-caption при редактировании', () => {
+    editor._test.body.innerHTML = `
+      <div class="mg-blog-carousel" data-mg-caption="Из блока">
+        <img src="/media/a.jpg"><img src="/media/b.jpg">
+      </div>
+    `;
+    editor.selection.getNode = () => editor._test.body.querySelector('.mg-blog-carousel');
+    blogCarouselEditButton.onAction();
+    const dialog = editor._test.getLastDialogConfig();
+    expect(dialog.initialData.alt).toBe('Из блока');
+  });
+
+  it('повторно привязывает dropzone в onOpen через setTimeout', async () => {
+    const dialog = openNewCarouselDialog();
+    const dropzonePanel = getDialogPanels(dialog).find((p) =>
+      p.html.includes('data-mg-carousel-dropzone'),
+    );
+    const panelEl = document.createElement('div');
+    panelEl.innerHTML = dropzonePanel.html;
+    document.body.appendChild(panelEl);
+
+    dialog.onOpen();
+    vi.runAllTimers();
+    dropzonePanel.onInit(panelEl);
+
+    const input = panelEl.querySelector('[data-mg-carousel-input]');
+    Object.defineProperty(input, 'files', {
+      value: createFileList([createMockFile('a.jpg'), createMockFile('b.jpg')]),
+      configurable: true,
+    });
+    input.dispatchEvent(new Event('change'));
+
+    window.djangoTinyMCEUploadImageFile.mockResolvedValue('/media/x.jpg');
+    const api = submitDialog(dialog);
+    await vi.waitFor(() => expect(api.close).toHaveBeenCalled());
+  });
+});

--- a/frontend/js/tinymce/tinymce_content_image.test.js
+++ b/frontend/js/tinymce/tinymce_content_image.test.js
@@ -1,0 +1,193 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { createMockTinyMCEEditor } from '../test/tinymce-helpers.js';
+
+describe('tinymce_content_image', () => {
+  beforeEach(async () => {
+    vi.resetModules();
+    vi.useFakeTimers();
+    delete window.djangoTinyMCESetupContentImage;
+    delete window.djangoTinyMCEImagesUploadHandler;
+    await import('@static/tinymce/js/tinymce_content_image.js');
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    document.body.innerHTML = '';
+    delete window.djangoTinyMCESetupContentImage;
+    delete window.djangoTinyMCEImagesUploadHandler;
+  });
+
+  function setupEditor(html = '') {
+    const editor = createMockTinyMCEEditor(html);
+    window.djangoTinyMCESetupContentImage(editor);
+    return editor;
+  }
+
+  it('регистрирует setup на window', () => {
+    expect(typeof window.djangoTinyMCESetupContentImage).toBe('function');
+  });
+
+  it('не ресайзит изображения внутри карусели', () => {
+    const editor = setupEditor(`
+      <div class="mg-blog-carousel">
+        <img src="/media/c.jpg" width="999">
+      </div>
+    `);
+    vi.runAllTimers();
+
+    const img = editor.getBody().querySelector('img');
+    expect(img.getAttribute('width')).toBe('999');
+    expect(img.getAttribute('data-mg-content-sized')).toBeNull();
+  });
+
+  it('устанавливает 200px по высоте для вертикального одиночного фото', () => {
+    const editor = setupEditor('<img src="/media/tall.jpg">');
+    const img = editor.getBody().querySelector('img');
+    Object.defineProperty(img, 'naturalWidth', { value: 400, configurable: true });
+    Object.defineProperty(img, 'naturalHeight', { value: 800, configurable: true });
+    Object.defineProperty(img, 'complete', { value: true, configurable: true });
+
+    editor.trigger('init');
+    vi.runAllTimers();
+
+    expect(img.getAttribute('height')).toBe('200');
+    expect(img.getAttribute('data-mg-content-sized')).toBe('true');
+    expect(img.getAttribute('style')).toContain('height: 200px');
+  });
+
+  it('устанавливает 200px по ширине для горизонтального одиночного фото', () => {
+    const editor = setupEditor('<img src="/media/wide.jpg">');
+    const img = editor.getBody().querySelector('img');
+    Object.defineProperty(img, 'naturalWidth', { value: 1200, configurable: true });
+    Object.defineProperty(img, 'naturalHeight', { value: 600, configurable: true });
+    Object.defineProperty(img, 'complete', { value: true, configurable: true });
+
+    editor.trigger('init');
+    vi.runAllTimers();
+
+    expect(img.getAttribute('width')).toBe('200');
+    expect(img.getAttribute('data-mg-content-sized')).toBe('true');
+  });
+
+  it('оборачивает одиночное изображение в параграф и убирает float', () => {
+    const editor = setupEditor(
+      '<img src="/media/f.jpg" class="alignleft" style="float:left;margin-left:10px">',
+    );
+    const img = editor.getBody().querySelector('img');
+    Object.defineProperty(img, 'naturalWidth', { value: 800, configurable: true });
+    Object.defineProperty(img, 'naturalHeight', { value: 600, configurable: true });
+    Object.defineProperty(img, 'complete', { value: true, configurable: true });
+
+    editor.trigger('init');
+    vi.runAllTimers();
+
+    const parent = img.parentElement;
+    expect(parent?.nodeName).toBe('P');
+    expect(img.style.float).toBe('');
+    expect(img.className).not.toContain('alignleft');
+  });
+
+  it('разделяет несколько img в одном блоке на отдельные параграфы', () => {
+    const editor = setupEditor(`
+      <p>
+        <img src="/media/1.jpg">
+        <img src="/media/2.jpg">
+      </p>
+    `);
+    const imgs = editor.getBody().querySelectorAll('img');
+    imgs.forEach((img) => {
+      Object.defineProperty(img, 'naturalWidth', { value: 800, configurable: true });
+      Object.defineProperty(img, 'naturalHeight', { value: 600, configurable: true });
+      Object.defineProperty(img, 'complete', { value: true, configurable: true });
+    });
+
+    editor.trigger('init');
+    vi.runAllTimers();
+
+    const paragraphs = editor.getBody().querySelectorAll('p');
+    expect(paragraphs.length).toBeGreaterThanOrEqual(2);
+    paragraphs.forEach((p) => {
+      expect(p.querySelectorAll('img').length).toBeLessThanOrEqual(1);
+    });
+  });
+
+  it('синхронизирует data-mg-caption на обёртке по alt', () => {
+    const editor = setupEditor('<p><img src="/media/cap.jpg" alt="Закат"></p>');
+    const img = editor.getBody().querySelector('img');
+    Object.defineProperty(img, 'naturalWidth', { value: 800, configurable: true });
+    Object.defineProperty(img, 'naturalHeight', { value: 600, configurable: true });
+    Object.defineProperty(img, 'complete', { value: true, configurable: true });
+
+    editor.trigger('init');
+    vi.runAllTimers();
+
+    const wrapper = img.parentElement;
+    expect(wrapper?.getAttribute('data-mg-caption')).toBe('Закат');
+    expect(img.getAttribute('data-mg-caption')).toBeNull();
+  });
+
+  it('удаляет data-mg-caption у одиночных блоков при PostProcess', () => {
+    const editor = setupEditor('');
+    const payload = {
+      get: true,
+      content:
+        '<p data-mg-caption="Тест"><img src="/x.jpg" alt="Тест"></p>' +
+        '<div class="mg-blog-carousel" data-mg-caption="Карусель"><img src="/y.jpg"></div>',
+    };
+    editor.trigger('PostProcess', payload);
+
+    expect(payload.content).toContain('mg-blog-carousel');
+    expect(payload.content).toContain('data-mg-caption="Карусель"');
+    expect(payload.content).not.toMatch(/<p[^>]*data-mg-caption/);
+  });
+
+  it('оборачивает загрузчик изображений и планирует ресайз', async () => {
+    const originalHandler = vi.fn().mockResolvedValue('/media/new.jpg');
+    window.djangoTinyMCEImagesUploadHandler = originalHandler;
+
+    const editor = setupEditor('<img src="/media/new.jpg">');
+    const img = editor.getBody().querySelector('img');
+    Object.defineProperty(img, 'naturalWidth', { value: 1000, configurable: true });
+    Object.defineProperty(img, 'naturalHeight', { value: 500, configurable: true });
+    Object.defineProperty(img, 'complete', { value: true, configurable: true });
+
+    const blobInfo = {
+      blob: () => new File(['x'], 'u.jpg', { type: 'image/jpeg' }),
+      filename: () => 'u.jpg',
+      width: () => 1000,
+      height: () => 500,
+    };
+
+    const handler = editor.options.set.mock.calls.find(
+      (c) => c[0] === 'images_upload_handler',
+    )?.[1];
+    expect(handler).toBeTypeOf('function');
+
+    await handler(blobInfo, vi.fn());
+    vi.advanceTimersByTime(100);
+
+    expect(originalHandler).toHaveBeenCalled();
+    expect(img.getAttribute('data-mg-content-sized')).toBe('true');
+  });
+
+  it('плановый scan ресайзит изображение после Change', () => {
+    const editor = setupEditor('<img src="/media/obs.jpg">');
+    const img = editor.getBody().querySelector('img');
+    Object.defineProperty(img, 'naturalWidth', { value: 400, configurable: true });
+    Object.defineProperty(img, 'naturalHeight', { value: 900, configurable: true });
+    Object.defineProperty(img, 'complete', { value: true, configurable: true });
+
+    editor.trigger('Change');
+    vi.runAllTimers();
+
+    expect(img.getAttribute('data-mg-content-sized')).toBe('true');
+    expect(img.getAttribute('height')).toBe('200');
+  });
+
+  it('помечает img как sized после ObjectResized', () => {
+    const editor = setupEditor('<img src="/media/r.jpg">');
+    const img = editor.getBody().querySelector('img');
+    editor.trigger('ObjectResized', { target: img });
+    expect(img.getAttribute('data-mg-content-sized')).toBe('true');
+  });
+});

--- a/frontend/js/tinymce/tinymce_csrf_upload.test.js
+++ b/frontend/js/tinymce/tinymce_csrf_upload.test.js
@@ -1,0 +1,193 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+describe('tinymce_csrf_upload', () => {
+  /** @type {typeof import('./tinymce_csrf_upload.js')} */
+  let uploadModuleLoaded;
+  let cookieValue = '';
+
+  beforeEach(async () => {
+    vi.resetModules();
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockRejectedValue(new Error('fetch should be mocked per test')),
+    );
+    cookieValue = 'csrftoken=test-csrf-token';
+    vi.spyOn(document, 'cookie', 'get').mockImplementation(() => cookieValue);
+    vi.spyOn(document, 'cookie', 'set').mockImplementation((value) => {
+      cookieValue = value;
+    });
+    await import('@static/tinymce/js/tinymce_csrf_upload.js');
+    uploadModuleLoaded = true;
+  });
+
+  afterEach(() => {
+    cookieValue = '';
+    delete window.djangoTinyMCEUploadImageFile;
+    delete window.djangoTinyMCEImagesUploadHandler;
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('экспортирует обработчики на window', () => {
+    expect(uploadModuleLoaded).toBe(true);
+    expect(typeof window.djangoTinyMCEUploadImageFile).toBe('function');
+    expect(typeof window.djangoTinyMCEImagesUploadHandler).toBe('function');
+  });
+
+  it('отклоняет загрузку без CSRF-токена', async () => {
+    cookieValue = '';
+    const file = new File(['data'], 'a.jpg', { type: 'image/jpeg' });
+    await expect(window.djangoTinyMCEUploadImageFile(file, 'a.jpg')).rejects.toBe(
+      'CSRF token not found',
+    );
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it('загружает через fetch без onProgress', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ location: '/media/uploaded.jpg' }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const file = new File(['data'], 'pic.jpg', { type: 'image/jpeg' });
+    const url = await window.djangoTinyMCEUploadImageFile(file, 'pic.jpg');
+
+    expect(url).toBe('/media/uploaded.jpg');
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/tinymce/upload-image/',
+      expect.objectContaining({
+        method: 'POST',
+        credentials: 'same-origin',
+        headers: { 'X-CSRFToken': 'test-csrf-token' },
+      }),
+    );
+  });
+
+  it('отклоняет fetch-ответ без location', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ error: 'bad file' }),
+      }),
+    );
+
+    const file = new File(['data'], 'pic.jpg', { type: 'image/jpeg' });
+    await expect(window.djangoTinyMCEUploadImageFile(file)).rejects.toBe(
+      'No location in response',
+    );
+  });
+
+  it('загружает через XHR с onProgress', async () => {
+    const progressCalls = [];
+    class MockXHR {
+      constructor() {
+        this.upload = { onprogress: null };
+        this.status = 200;
+        this.responseText = JSON.stringify({ location: '/media/xhr.jpg' });
+        MockXHR.lastInstance = this;
+      }
+
+      open() {}
+
+      setRequestHeader() {}
+
+      send() {
+        this.upload.onprogress?.({
+          lengthComputable: true,
+          loaded: 50,
+          total: 100,
+        });
+        this.onload?.();
+      }
+    }
+    MockXHR.lastInstance = null;
+    vi.stubGlobal('XMLHttpRequest', MockXHR);
+
+    const file = new File(['data'], 'xhr.jpg', { type: 'image/jpeg' });
+    const url = await window.djangoTinyMCEUploadImageFile(file, 'xhr.jpg', {
+      onProgress: (p) => progressCalls.push(p),
+    });
+
+    expect(url).toBe('/media/xhr.jpg');
+    expect(progressCalls).toContain(50);
+    expect(MockXHR.lastInstance.withCredentials).toBe(true);
+  });
+
+  it('отклоняет XHR при невалидном JSON', async () => {
+    class MockXHR {
+      constructor() {
+        this.upload = { onprogress: null };
+        this.status = 200;
+        this.responseText = 'not json';
+      }
+
+      open() {}
+
+      setRequestHeader() {}
+
+      send() {
+        this.onload?.();
+      }
+    }
+    vi.stubGlobal('XMLHttpRequest', MockXHR);
+
+    const file = new File(['data'], 'bad.jpg', { type: 'image/jpeg' });
+    await expect(
+      window.djangoTinyMCEUploadImageFile(file, 'bad.jpg', { onProgress: () => {} }),
+    ).rejects.toBe('Upload failed: invalid response');
+  });
+
+  it('отклоняет XHR при HTTP-ошибке', async () => {
+    class MockXHR {
+      constructor() {
+        this.upload = { onprogress: null };
+        this.status = 403;
+        this.responseText = '';
+      }
+
+      open() {}
+
+      setRequestHeader() {}
+
+      send() {
+        this.onload?.();
+      }
+    }
+    vi.stubGlobal('XMLHttpRequest', MockXHR);
+
+    const file = new File(['data'], 'denied.jpg', { type: 'image/jpeg' });
+    await expect(
+      window.djangoTinyMCEUploadImageFile(file, 'denied.jpg', { onProgress: () => {} }),
+    ).rejects.toBe('Upload failed: 403');
+  });
+
+  it('djangoTinyMCEImagesUploadHandler проксирует blobInfo через XHR', async () => {
+    class MockXHR {
+      constructor() {
+        this.upload = { onprogress: null };
+        this.status = 200;
+        this.responseText = JSON.stringify({ location: '/media/handler.jpg' });
+      }
+
+      open() {}
+
+      setRequestHeader() {}
+
+      send() {
+        this.onload?.();
+      }
+    }
+    vi.stubGlobal('XMLHttpRequest', MockXHR);
+
+    const progress = vi.fn();
+    const blobInfo = {
+      blob: () => new File(['b'], 'from-blob.jpg', { type: 'image/jpeg' }),
+      filename: () => 'from-blob.jpg',
+    };
+
+    const url = await window.djangoTinyMCEImagesUploadHandler(blobInfo, progress);
+    expect(url).toBe('/media/handler.jpg');
+  });
+});

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -78,6 +78,7 @@ export default defineConfig({
         'css/leaflet-controls': path.resolve(__dirname, 'css/leaflet-controls.css'),
         'css/geo_polygons': path.resolve(__dirname, 'css/geo_polygons.css'),
         'css/content_image_gallery': path.resolve(__dirname, 'css/content_image_gallery.css'),
+        'css/blog_content_carousel': path.resolve(__dirname, 'css/blog_content_carousel.css'),
         'css/ui-lib': path.resolve(__dirname, 'ui-lib/styles/index.css'),
       }
     }

--- a/frontend/vitest.config.mjs
+++ b/frontend/vitest.config.mjs
@@ -1,8 +1,18 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { defineConfig } from 'vitest/config';
 
+const frontendRoot = path.dirname(fileURLToPath(import.meta.url));
+const projectRoot = path.resolve(frontendRoot, '..');
+
 export default defineConfig({
+  resolve: {
+    alias: {
+      '@static': path.join(projectRoot, 'static'),
+    },
+  },
   test: {
     environment: 'happy-dom',
-    include: ['ui-lib/**/*.test.js'],
+    include: ['ui-lib/**/*.test.js', 'js/**/*.test.js'],
   },
 });

--- a/static/tinymce/js/tinymce_blog_carousel_multiselect.js
+++ b/static/tinymce/js/tinymce_blog_carousel_multiselect.js
@@ -1,6 +1,6 @@
 /**
  * Кнопка TinyMCE «Карусель» в админке статей блога.
- * Зона загрузки повторяет разметку dropzone TinyMCE, input — свой с multiple.
+ * Вставка и редактирование блока .mg-blog-carousel.
  */
 (function () {
   'use strict';
@@ -27,6 +27,7 @@
 
   function buildCarouselHtml(urls, alt) {
     var altAttr = alt ? ' alt="' + escapeAttr(alt) + '"' : '';
+    var captionAttr = alt ? ' data-mg-caption="' + escapeAttr(alt) + '"' : '';
     var imgs = urls
       .map(function (url) {
         return (
@@ -43,10 +44,38 @@
     return (
       '<div class="' +
       CAROUSEL_CLASS +
-      '" contenteditable="false" data-mg-blog-carousel>' +
+      '" contenteditable="false" data-mg-blog-carousel' +
+      captionAttr +
+      '>' +
       imgs +
       '</div><p></p>'
     );
+  }
+
+  function parseCarouselElement(carouselEl) {
+    var urls = [];
+    var imgs = carouselEl.getElementsByTagName('img');
+    for (var i = 0; i < imgs.length; i++) {
+      var src = imgs[i].getAttribute('src');
+      if (src) {
+        urls.push(src);
+      }
+    }
+    var alt = carouselEl.getAttribute('data-mg-caption') || '';
+    if (!alt && imgs.length > 0) {
+      alt = imgs[0].getAttribute('alt') || '';
+    }
+    return { urls: urls, alt: alt };
+  }
+
+  function findCarouselNode(node, editor) {
+    if (!node) {
+      return null;
+    }
+    if (node.nodeType === 1 && editor.dom.hasClass(node, CAROUSEL_CLASS)) {
+      return node;
+    }
+    return editor.dom.getParent(node, '.' + CAROUSEL_CLASS);
   }
 
   function reportOverallProgress(done, total, filePercent, onProgress) {
@@ -135,6 +164,35 @@
     return result;
   }
 
+  function buildExistingSlidesHtml(urls) {
+    if (!urls.length) {
+      return '';
+    }
+    var items = urls
+      .map(function (url) {
+        return (
+          '<div class="mg-carousel-existing" data-mg-url="' +
+          escapeAttr(url) +
+          '" style="display:flex;align-items:center;gap:8px;margin:6px 0;">' +
+          '<img src="' +
+          escapeAttr(url) +
+          '" alt="" style="width:64px;height:48px;object-fit:cover;border-radius:4px;flex-shrink:0;">' +
+          '<span style="flex:1;font-size:12px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;color:rgba(34,47,62,.75);">' +
+          escapeHtml(url) +
+          '</span>' +
+          '<button type="button" class="tox-button tox-button--secondary tox-button--naked" data-mg-remove-slide>Удалить</button>' +
+          '</div>'
+        );
+      })
+      .join('');
+    return (
+      '<div data-mg-existing-slides style="margin-bottom:12px;">' +
+      '<p style="margin:0 0 6px;font-size:13px;font-weight:600;color:rgba(34,47,62,.85);">Текущие фото</p>' +
+      items +
+      '</div>'
+    );
+  }
+
   function buildDropzoneHtml(editor, inputId) {
     return (
       '<div class="tox-form__group tox-form__group--stretched">' +
@@ -156,13 +214,13 @@
       '</div>' +
       '</div>' +
       '<p data-mg-carousel-file-count style="margin:8px 0 0;font-size:13px;color:rgba(34,47,62,.7);">' +
-      'Выбрано файлов: 0</p>' +
+      'Новых файлов: 0</p>' +
       '<p style="margin:4px 0 0;font-size:12px;color:rgba(34,47,62,.55);">' +
       'От ' +
       MIN_IMAGES +
       ' до ' +
       MAX_IMAGES +
-      ' изображений. Можно выбрать несколько сразу (Ctrl+клик) или перетащить.</p>'
+      ' изображений в карусели. Можно выбрать несколько сразу (Ctrl+клик) или перетащить.</p>'
     );
   }
 
@@ -177,7 +235,7 @@
       if (!countEl) {
         return;
       }
-      countEl.textContent = 'Выбрано файлов: ' + selectedFiles.length + ' (макс. ' + MAX_IMAGES + ')';
+      countEl.textContent = 'Новых файлов: ' + selectedFiles.length;
     }
 
     function addFiles(fileList) {
@@ -247,93 +305,231 @@
     return Boolean(holder.state);
   }
 
+  function findNodeUp(startNode, rootEl, attrName) {
+    var node = startNode;
+    while (node && node !== rootEl) {
+      if (node.nodeType === 1 && node.getAttribute && node.getAttribute(attrName) !== null) {
+        return node;
+      }
+      node = node.parentNode;
+    }
+    return null;
+  }
+
+  function collectExistingUrls(panelEl) {
+    if (!panelEl) {
+      return [];
+    }
+    var container = panelEl.querySelector('[data-mg-existing-slides]') || panelEl;
+    var urls = [];
+    var rows = container.querySelectorAll('[data-mg-url]');
+    for (var i = 0; i < rows.length; i++) {
+      var url = rows[i].getAttribute('data-mg-url');
+      if (url) {
+        urls.push(url);
+      }
+    }
+    return urls;
+  }
+
+  function bindExistingSlides(panelEl) {
+    if (!panelEl || panelEl.getAttribute('data-mg-slides-bound') === 'true') {
+      return;
+    }
+    panelEl.setAttribute('data-mg-slides-bound', 'true');
+
+    panelEl.addEventListener('click', function (e) {
+      var btn = findNodeUp(e.target, panelEl, 'data-mg-remove-slide');
+      if (!btn) {
+        return;
+      }
+      e.preventDefault();
+      e.stopPropagation();
+
+      var row = findNodeUp(btn, panelEl, 'data-mg-url');
+      if (row && row.parentNode) {
+        row.parentNode.removeChild(row);
+      }
+    });
+  }
+
+  function openCarouselDialog(editor, options) {
+    options = options || {};
+    var isEdit = Boolean(options.editNode);
+    var editNode = options.editNode || null;
+    var parsed = isEdit && editNode ? parseCarouselElement(editNode) : { urls: [], alt: '' };
+
+    var fileHolder = { state: null };
+    var dialogUi = { existingPanelEl: null, dropzonePanelEl: null };
+    var inputId = 'mg-carousel-input-' + String(Date.now());
+    var panelItems = [];
+
+    if (isEdit) {
+      panelItems.push({
+        type: 'htmlpanel',
+        html: buildExistingSlidesHtml(parsed.urls),
+        onInit: function (el) {
+          dialogUi.existingPanelEl = el;
+          bindExistingSlides(el);
+        }
+      });
+    }
+
+    panelItems.push(
+      {
+        type: 'htmlpanel',
+        html: buildDropzoneHtml(editor, inputId),
+        onInit: function (el) {
+          dialogUi.dropzonePanelEl = el;
+          bindFileSelection(el, fileHolder);
+        }
+      },
+      {
+        type: 'input',
+        name: 'alt',
+        label: 'Подпись (для всех фото)'
+      }
+    );
+
+    editor.windowManager.open({
+      title: isEdit ? 'Изменить карусель' : 'Карусель фотографий',
+      size: 'normal',
+      body: {
+        type: 'panel',
+        items: panelItems
+      },
+      initialData: {
+        alt: parsed.alt
+      },
+      buttons: [
+        { type: 'cancel', text: 'Отмена' },
+        {
+          type: 'submit',
+          text: isEdit ? 'Сохранить' : 'Загрузить и вставить',
+          primary: true
+        }
+      ],
+      onOpen: function () {
+        window.setTimeout(function () {
+          if (!fileHolder.state && dialogUi.dropzonePanelEl) {
+            bindFileSelection(dialogUi.dropzonePanelEl, fileHolder);
+          }
+          if (isEdit && dialogUi.existingPanelEl) {
+            bindExistingSlides(dialogUi.existingPanelEl);
+          }
+        }, 0);
+      },
+      onClose: function () {
+        fileHolder.state = null;
+        dialogUi.existingPanelEl = null;
+        dialogUi.dropzonePanelEl = null;
+      },
+      onSubmit: function (api) {
+        if (!fileHolder.state && dialogUi.dropzonePanelEl) {
+          bindFileSelection(dialogUi.dropzonePanelEl, fileHolder);
+        }
+
+        var existingUrls = isEdit ? collectExistingUrls(dialogUi.existingPanelEl) : [];
+        var newFiles = fileHolder.state ? fileHolder.state.getFiles() : [];
+        var totalCount = existingUrls.length + newFiles.length;
+
+        if (totalCount < MIN_IMAGES) {
+          editor.windowManager.alert(
+            'В карусели должно быть минимум ' + MIN_IMAGES + ' изображения.'
+          );
+          return;
+        }
+
+        if (totalCount > MAX_IMAGES) {
+          editor.windowManager.alert(
+            'В карусели может быть не более ' + MAX_IMAGES + ' изображений.'
+          );
+          return;
+        }
+
+        if (fileHolder.state && fileHolder.state.wasLimitExceeded()) {
+          editor.windowManager.alert(
+            'Выбрано больше ' +
+              MAX_IMAGES +
+              ' новых файлов — будут загружены только первые ' +
+              MAX_IMAGES +
+              '.'
+          );
+        }
+
+        var alt = (api.getData().alt || '').trim();
+
+        function setUploadProgress(percent) {
+          api.block(isEdit ? 'Сохранение… ' + percent + '%' : 'Загрузка… ' + percent + '%');
+        }
+
+        function finish(urls) {
+          if (isEdit && editNode) {
+            editor.undoManager.transact(function () {
+              editor.dom.setOuterHTML(editNode, buildCarouselHtml(urls, alt));
+            });
+          } else {
+            editor.insertContent(buildCarouselHtml(urls, alt));
+          }
+          api.close();
+        }
+
+        if (!newFiles.length) {
+          finish(existingUrls);
+          return;
+        }
+
+        setUploadProgress(0);
+        uploadFiles(newFiles, setUploadProgress)
+          .then(function (uploadedUrls) {
+            finish(existingUrls.concat(uploadedUrls));
+          })
+          .catch(function (err) {
+            api.unblock();
+            var message =
+              typeof err === 'string' ? err : err && err.message ? err.message : 'Ошибка загрузки';
+            editor.windowManager.alert(message);
+          });
+      }
+    });
+  }
+
   function djangoTinyMCESetupBlogCarousel(editor) {
     editor.ui.registry.addButton('blog_carousel', {
       text: 'Карусель',
-      tooltip:
-        'Вставить карусель из ' + MIN_IMAGES + '–' + MAX_IMAGES + ' фотографий',
+      tooltip: 'Вставить карусель из ' + MIN_IMAGES + '–' + MAX_IMAGES + ' фотографий',
       onAction: function () {
-        var fileHolder = { state: null };
-        var inputId = 'mg-carousel-input-' + String(Date.now());
+        openCarouselDialog(editor, {});
+      }
+    });
 
-        editor.windowManager.open({
-          title: 'Карусель фотографий',
-          size: 'normal',
-          body: {
-            type: 'panel',
-            items: [
-              {
-                type: 'htmlpanel',
-                html: buildDropzoneHtml(editor, inputId),
-                onInit: function (el) {
-                  bindFileSelection(el, fileHolder);
-                }
-              },
-              {
-                type: 'input',
-                name: 'alt',
-                label: 'Подпись (для всех фото)'
-              }
-            ]
-          },
-          buttons: [
-            { type: 'cancel', text: 'Отмена' },
-            { type: 'submit', text: 'Загрузить и вставить', primary: true }
-          ],
-          onOpen: function (api) {
-            window.setTimeout(function () {
-              if (!fileHolder.state) {
-                bindFileSelection(api.getEl(), fileHolder);
-              }
-            }, 0);
-          },
-          onClose: function () {
-            fileHolder.state = null;
-          },
-          onSubmit: function (api) {
-            if (!fileHolder.state) {
-              bindFileSelection(api.getEl(), fileHolder);
-            }
+    editor.ui.registry.addButton('blog_carousel_edit', {
+      text: 'Изменить карусель',
+      tooltip: 'Изменить выбранную карусель фотографий',
+      onAction: function () {
+        var carousel = findCarouselNode(editor.selection.getNode(), editor);
+        if (!carousel) {
+          editor.windowManager.alert('Выберите карусель в тексте статьи.');
+          return;
+        }
+        openCarouselDialog(editor, { editNode: carousel });
+      }
+    });
 
-            var fileinput = fileHolder.state ? fileHolder.state.getFiles() : [];
+    editor.ui.registry.addContextToolbar('mgBlogCarouselToolbar', {
+      predicate: function (node) {
+        return Boolean(findCarouselNode(node, editor));
+      },
+      items: 'blog_carousel_edit',
+      position: 'node',
+      scope: 'node'
+    });
 
-            if (!fileinput.length || fileinput.length < MIN_IMAGES) {
-              editor.windowManager.alert(
-                'Нужно выбрать минимум ' + MIN_IMAGES + ' изображения.'
-              );
-              return;
-            }
-
-            if (fileHolder.state && fileHolder.state.wasLimitExceeded()) {
-              editor.windowManager.alert(
-                'Выбрано больше ' +
-                  MAX_IMAGES +
-                  ' файлов — в карусель попадут только первые ' +
-                  MAX_IMAGES +
-                  '.'
-              );
-            }
-
-            var alt = (api.getData().alt || '').trim();
-
-            function setUploadProgress(percent) {
-              api.block('Загрузка… ' + percent + '%');
-            }
-
-            setUploadProgress(0);
-            uploadFiles(fileinput, setUploadProgress)
-              .then(function (urls) {
-                editor.insertContent(buildCarouselHtml(urls, alt));
-                api.close();
-              })
-              .catch(function (err) {
-                api.unblock();
-                var message =
-                  typeof err === 'string' ? err : err && err.message ? err.message : 'Ошибка загрузки';
-                editor.windowManager.alert(message);
-              });
-          }
-        });
+    editor.on('dblclick', function (event) {
+      var carousel = findCarouselNode(event.target, editor);
+      if (carousel) {
+        event.preventDefault();
+        openCarouselDialog(editor, { editNode: carousel });
       }
     });
   }

--- a/static/tinymce/js/tinymce_blog_carousel_multiselect.js
+++ b/static/tinymce/js/tinymce_blog_carousel_multiselect.js
@@ -9,7 +9,8 @@
   var MIN_IMAGES = 2;
   var MAX_IMAGES = 10;
   var UPLOAD_CONCURRENCY = 3;
-  var CONTENT_IMAGE_WIDTH = 500;
+  /** Превью в админке; на сайте — 500px (blog_content_carousel.js). */
+  var CONTENT_IMAGE_WIDTH = 200;
 
   function escapeAttr(str) {
     return String(str)

--- a/static/tinymce/js/tinymce_blog_carousel_multiselect.js
+++ b/static/tinymce/js/tinymce_blog_carousel_multiselect.js
@@ -1,0 +1,342 @@
+/**
+ * Кнопка TinyMCE «Карусель» в админке статей блога.
+ * Зона загрузки повторяет разметку dropzone TinyMCE, input — свой с multiple.
+ */
+(function () {
+  'use strict';
+
+  var CAROUSEL_CLASS = 'mg-blog-carousel';
+  var MIN_IMAGES = 2;
+  var MAX_IMAGES = 10;
+  var UPLOAD_CONCURRENCY = 3;
+  var CONTENT_IMAGE_WIDTH = 500;
+
+  function escapeAttr(str) {
+    return String(str)
+      .replace(/&/g, '&amp;')
+      .replace(/"/g, '&quot;')
+      .replace(/</g, '&lt;');
+  }
+
+  function escapeHtml(str) {
+    return String(str)
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;');
+  }
+
+  function buildCarouselHtml(urls, alt) {
+    var altAttr = alt ? ' alt="' + escapeAttr(alt) + '"' : '';
+    var imgs = urls
+      .map(function (url) {
+        return (
+          '<img src="' +
+          escapeAttr(url) +
+          '" width="' +
+          CONTENT_IMAGE_WIDTH +
+          '"' +
+          altAttr +
+          '>'
+        );
+      })
+      .join('');
+    return (
+      '<div class="' +
+      CAROUSEL_CLASS +
+      '" contenteditable="false" data-mg-blog-carousel>' +
+      imgs +
+      '</div><p></p>'
+    );
+  }
+
+  function reportOverallProgress(done, total, filePercent, onProgress) {
+    if (!onProgress || total <= 0) {
+      return;
+    }
+    var base = (done / total) * 100;
+    var slice = filePercent / total;
+    onProgress(Math.min(100, Math.round(base + slice)));
+  }
+
+  function uploadSingleFile(file, done, total, onProgress) {
+    return new Promise(function (resolve, reject) {
+      window
+        .djangoTinyMCEUploadImageFile(file, file.name, {
+          onProgress: function (filePercent) {
+            reportOverallProgress(done, total, filePercent, onProgress);
+          }
+        })
+        .then(resolve)
+        .catch(reject);
+    });
+  }
+
+  function uploadFiles(files, onProgress) {
+    if (!window.djangoTinyMCEUploadImageFile) {
+      return Promise.reject('Загрузка изображений недоступна');
+    }
+
+    var total = files.length;
+    var results = new Array(total);
+    var nextIndex = 0;
+    var completed = 0;
+
+    function runWorker() {
+      if (nextIndex >= total) {
+        return Promise.resolve();
+      }
+
+      var index = nextIndex;
+      nextIndex += 1;
+
+      return uploadSingleFile(files[index], completed, total, onProgress)
+        .then(function (url) {
+          results[index] = url;
+          completed += 1;
+          reportOverallProgress(completed, total, 0, onProgress);
+        })
+        .then(runWorker);
+    }
+
+    var workers = [];
+    var pool = Math.min(UPLOAD_CONCURRENCY, total);
+    for (var i = 0; i < pool; i++) {
+      workers.push(runWorker());
+    }
+
+    return Promise.all(workers).then(function () {
+      return results;
+    });
+  }
+
+  function filesToArray(fileList) {
+    var arr = [];
+    for (var i = 0; i < fileList.length; i++) {
+      arr.push(fileList[i]);
+    }
+    return arr;
+  }
+
+  function fileKey(file) {
+    return file.name + '|' + file.size + '|' + file.lastModified;
+  }
+
+  function mergeFiles(existing, incoming) {
+    var seen = {};
+    var result = [];
+    var all = existing.concat(incoming);
+    for (var i = 0; i < all.length; i++) {
+      var key = fileKey(all[i]);
+      if (!seen[key]) {
+        seen[key] = true;
+        result.push(all[i]);
+      }
+    }
+    return result;
+  }
+
+  function buildDropzoneHtml(editor, inputId) {
+    return (
+      '<div class="tox-form__group tox-form__group--stretched">' +
+      '<div class="tox-dropzone-container">' +
+      '<div class="tox-dropzone" data-mg-carousel-dropzone>' +
+      '<p>' +
+      escapeHtml(editor.translate('Drop an image here')) +
+      '</p>' +
+      '<input type="file" id="' +
+      escapeAttr(inputId) +
+      '" data-mg-carousel-input accept="image/*" multiple tabindex="-1" ' +
+      'style="position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0;">' +
+      '<label for="' +
+      escapeAttr(inputId) +
+      '" class="tox-button tox-button--secondary" data-mg-carousel-browse>' +
+      escapeHtml(editor.translate('Browse for an image')) +
+      '</label>' +
+      '</div>' +
+      '</div>' +
+      '</div>' +
+      '<p data-mg-carousel-file-count style="margin:8px 0 0;font-size:13px;color:rgba(34,47,62,.7);">' +
+      'Выбрано файлов: 0</p>' +
+      '<p style="margin:4px 0 0;font-size:12px;color:rgba(34,47,62,.55);">' +
+      'От ' +
+      MIN_IMAGES +
+      ' до ' +
+      MAX_IMAGES +
+      ' изображений. Можно выбрать несколько сразу (Ctrl+клик) или перетащить.</p>'
+    );
+  }
+
+  function createFileSelectionState(rootEl) {
+    var selectedFiles = [];
+    var input = rootEl.querySelector('[data-mg-carousel-input]');
+    var dropzone = rootEl.querySelector('[data-mg-carousel-dropzone]');
+    var countEl = rootEl.querySelector('[data-mg-carousel-file-count]');
+    var limitExceeded = false;
+
+    function updateCount() {
+      if (!countEl) {
+        return;
+      }
+      countEl.textContent = 'Выбрано файлов: ' + selectedFiles.length + ' (макс. ' + MAX_IMAGES + ')';
+    }
+
+    function addFiles(fileList) {
+      if (!fileList || !fileList.length) {
+        return;
+      }
+      var merged = mergeFiles(selectedFiles, filesToArray(fileList));
+      if (merged.length > MAX_IMAGES) {
+        limitExceeded = true;
+        merged = merged.slice(0, MAX_IMAGES);
+      }
+      selectedFiles = merged;
+      updateCount();
+    }
+
+    if (!input) {
+      return null;
+    }
+
+    input.multiple = true;
+    input.setAttribute('multiple', 'multiple');
+    input.addEventListener('change', function () {
+      addFiles(input.files);
+      input.value = '';
+    });
+
+    if (dropzone) {
+      function setDragActive(active) {
+        if (active) {
+          dropzone.classList.add('dragenter');
+        } else {
+          dropzone.classList.remove('dragenter');
+        }
+      }
+
+      dropzone.addEventListener('dragenter', function (e) {
+        e.preventDefault();
+        setDragActive(true);
+      });
+      dropzone.addEventListener('dragleave', function () {
+        setDragActive(false);
+      });
+      dropzone.addEventListener('dragover', function (e) {
+        e.preventDefault();
+      });
+      dropzone.addEventListener('drop', function (e) {
+        e.preventDefault();
+        setDragActive(false);
+        if (e.dataTransfer && e.dataTransfer.files) {
+          addFiles(e.dataTransfer.files);
+        }
+      });
+    }
+
+    return {
+      getFiles: function () {
+        return selectedFiles.slice();
+      },
+      wasLimitExceeded: function () {
+        return limitExceeded;
+      }
+    };
+  }
+
+  function bindFileSelection(rootEl, holder) {
+    holder.state = createFileSelectionState(rootEl);
+    return Boolean(holder.state);
+  }
+
+  function djangoTinyMCESetupBlogCarousel(editor) {
+    editor.ui.registry.addButton('blog_carousel', {
+      text: 'Карусель',
+      tooltip:
+        'Вставить карусель из ' + MIN_IMAGES + '–' + MAX_IMAGES + ' фотографий',
+      onAction: function () {
+        var fileHolder = { state: null };
+        var inputId = 'mg-carousel-input-' + String(Date.now());
+
+        editor.windowManager.open({
+          title: 'Карусель фотографий',
+          size: 'normal',
+          body: {
+            type: 'panel',
+            items: [
+              {
+                type: 'htmlpanel',
+                html: buildDropzoneHtml(editor, inputId),
+                onInit: function (el) {
+                  bindFileSelection(el, fileHolder);
+                }
+              },
+              {
+                type: 'input',
+                name: 'alt',
+                label: 'Подпись (для всех фото)'
+              }
+            ]
+          },
+          buttons: [
+            { type: 'cancel', text: 'Отмена' },
+            { type: 'submit', text: 'Загрузить и вставить', primary: true }
+          ],
+          onOpen: function (api) {
+            window.setTimeout(function () {
+              if (!fileHolder.state) {
+                bindFileSelection(api.getEl(), fileHolder);
+              }
+            }, 0);
+          },
+          onClose: function () {
+            fileHolder.state = null;
+          },
+          onSubmit: function (api) {
+            if (!fileHolder.state) {
+              bindFileSelection(api.getEl(), fileHolder);
+            }
+
+            var fileinput = fileHolder.state ? fileHolder.state.getFiles() : [];
+
+            if (!fileinput.length || fileinput.length < MIN_IMAGES) {
+              editor.windowManager.alert(
+                'Нужно выбрать минимум ' + MIN_IMAGES + ' изображения.'
+              );
+              return;
+            }
+
+            if (fileHolder.state && fileHolder.state.wasLimitExceeded()) {
+              editor.windowManager.alert(
+                'Выбрано больше ' +
+                  MAX_IMAGES +
+                  ' файлов — в карусель попадут только первые ' +
+                  MAX_IMAGES +
+                  '.'
+              );
+            }
+
+            var alt = (api.getData().alt || '').trim();
+
+            function setUploadProgress(percent) {
+              api.block('Загрузка… ' + percent + '%');
+            }
+
+            setUploadProgress(0);
+            uploadFiles(fileinput, setUploadProgress)
+              .then(function (urls) {
+                editor.insertContent(buildCarouselHtml(urls, alt));
+                api.close();
+              })
+              .catch(function (err) {
+                api.unblock();
+                var message =
+                  typeof err === 'string' ? err : err && err.message ? err.message : 'Ошибка загрузки';
+                editor.windowManager.alert(message);
+              });
+          }
+        });
+      }
+    });
+  }
+
+  window.djangoTinyMCESetupBlogCarousel = djangoTinyMCESetupBlogCarousel;
+})();

--- a/static/tinymce/js/tinymce_content_image.js
+++ b/static/tinymce/js/tinymce_content_image.js
@@ -1,0 +1,236 @@
+/**
+ * Одиночные изображения в TinyMCE (только админка): после вставки/загрузки — 200px по большей стороне
+ * (как на странице статьи и в карусели).
+ */
+(function () {
+  'use strict';
+
+  var CONTENT_IMAGE_SIZE = 200;
+  var SIZED_ATTR = 'data-mg-content-sized';
+
+  function shouldResize(img, editor) {
+    if (!img || img.nodeName !== 'IMG') {
+      return false;
+    }
+    if (editor.dom.getParent(img, '.mg-blog-carousel')) {
+      return false;
+    }
+    if (img.getAttribute(SIZED_ATTR) === 'true') {
+      return false;
+    }
+    return true;
+  }
+
+  function commitStandardSize(editor, img, naturalWidth, naturalHeight) {
+    if (!naturalWidth || !naturalHeight) {
+      return false;
+    }
+
+    editor.dom.setAttrib(img, 'style', null);
+    editor.dom.setAttrib(img, 'width', null);
+    editor.dom.setAttrib(img, 'height', null);
+
+    if (naturalHeight > naturalWidth) {
+      editor.dom.setAttrib(img, 'height', String(CONTENT_IMAGE_SIZE));
+      editor.dom.setAttrib(
+        img,
+        'style',
+        'height: ' + CONTENT_IMAGE_SIZE + 'px; width: auto; max-width: 100%;'
+      );
+    } else {
+      editor.dom.setAttrib(img, 'width', String(CONTENT_IMAGE_SIZE));
+      editor.dom.setAttrib(
+        img,
+        'style',
+        'width: ' + CONTENT_IMAGE_SIZE + 'px; height: auto; max-width: 100%;'
+      );
+    }
+
+    editor.dom.setAttrib(img, SIZED_ATTR, 'true');
+    return true;
+  }
+
+  function applyStandardSize(editor, img, knownWidth, knownHeight) {
+    if (!shouldResize(img, editor)) {
+      return;
+    }
+
+    var naturalWidth = knownWidth || img.naturalWidth;
+    var naturalHeight = knownHeight || img.naturalHeight;
+
+    if (commitStandardSize(editor, img, naturalWidth, naturalHeight)) {
+      editor.nodeChanged();
+      return;
+    }
+
+    function onLoad() {
+      if (shouldResize(img, editor)) {
+        if (commitStandardSize(editor, img, img.naturalWidth, img.naturalHeight)) {
+          editor.nodeChanged();
+        }
+      }
+    }
+
+    img.addEventListener('load', onLoad, { once: true });
+
+    if (img.complete && img.naturalWidth && img.naturalHeight) {
+      onLoad();
+    }
+  }
+
+  function urlMatches(imgSrc, uploadedUrl) {
+    if (!imgSrc || !uploadedUrl) {
+      return false;
+    }
+    if (imgSrc === uploadedUrl) {
+      return true;
+    }
+    try {
+      return imgSrc === new URL(uploadedUrl, window.location.href).href;
+    } catch (e) {
+      return imgSrc.indexOf(uploadedUrl) !== -1 || uploadedUrl.indexOf(imgSrc) !== -1;
+    }
+  }
+
+  function scanUnsizedImages(editor, matchUrl, knownWidth, knownHeight) {
+    var body = editor.getBody();
+    if (!body) {
+      return;
+    }
+
+    var imgs = body.getElementsByTagName('img');
+    for (var i = 0; i < imgs.length; i++) {
+      var img = imgs[i];
+      if (matchUrl && !urlMatches(img.src, matchUrl)) {
+        continue;
+      }
+      applyStandardSize(editor, img, knownWidth, knownHeight);
+    }
+  }
+
+  function schedulePostUploadResize(editor, uploadedUrl, knownWidth, knownHeight) {
+    var delays = [0, 30, 100, 250, 500, 1000];
+    for (var d = 0; d < delays.length; d++) {
+      (function (delay) {
+        window.setTimeout(function () {
+          scanUnsizedImages(editor, uploadedUrl, knownWidth, knownHeight);
+        }, delay);
+      })(delays[d]);
+    }
+  }
+
+  function getOriginalUploadHandler() {
+    var handler = window.djangoTinyMCEImagesUploadHandler;
+    if (handler && handler.__mgOriginal) {
+      return handler.__mgOriginal;
+    }
+    return handler;
+  }
+
+  function createUploadHandler(editor) {
+    return function (blobInfo, progress) {
+      var knownWidth = typeof blobInfo.width === 'function' ? blobInfo.width() : 0;
+      var knownHeight = typeof blobInfo.height === 'function' ? blobInfo.height() : 0;
+
+      return getOriginalUploadHandler()(blobInfo, progress).then(function (url) {
+        schedulePostUploadResize(editor, url, knownWidth, knownHeight);
+        return url;
+      });
+    };
+  }
+
+  function bindImageSizeObserver(editor) {
+    var body = editor.getBody();
+    if (!body || body.getAttribute('data-mg-img-observer') === 'true') {
+      return;
+    }
+    body.setAttribute('data-mg-img-observer', 'true');
+
+    var observer = new MutationObserver(function (mutations) {
+      for (var i = 0; i < mutations.length; i++) {
+        var mutation = mutations[i];
+
+        if (mutation.type === 'childList') {
+          for (var j = 0; j < mutation.addedNodes.length; j++) {
+            var node = mutation.addedNodes[j];
+            if (!node || node.nodeType !== 1) {
+              continue;
+            }
+            if (node.nodeName === 'IMG') {
+              applyStandardSize(editor, node);
+            } else if (node.querySelectorAll) {
+              var addedImgs = node.querySelectorAll('img');
+              for (var k = 0; k < addedImgs.length; k++) {
+                applyStandardSize(editor, addedImgs[k]);
+              }
+            }
+          }
+        }
+
+        if (mutation.type === 'attributes' && mutation.target.nodeName === 'IMG') {
+          if (mutation.attributeName === SIZED_ATTR) {
+            continue;
+          }
+          applyStandardSize(editor, mutation.target);
+        }
+      }
+    });
+
+    observer.observe(body, {
+      childList: true,
+      subtree: true,
+      attributes: true,
+      attributeFilter: ['src', 'width', 'height', 'style']
+    });
+  }
+
+  function installUploadHandlerOnEditor(editor) {
+    if (!window.djangoTinyMCEImagesUploadHandler) {
+      return;
+    }
+    if (!window.djangoTinyMCEImagesUploadHandler.__mgOriginal) {
+      window.djangoTinyMCEImagesUploadHandler.__mgOriginal =
+        window.djangoTinyMCEImagesUploadHandler;
+    }
+
+    var handler = createUploadHandler(editor);
+    if (typeof editor.options !== 'undefined' && typeof editor.options.set === 'function') {
+      editor.options.set('images_upload_handler', handler);
+    } else if (editor.settings) {
+      editor.settings.images_upload_handler = handler;
+    }
+  }
+
+  function djangoTinyMCESetupContentImage(editor) {
+    installUploadHandlerOnEditor(editor);
+    bindImageSizeObserver(editor);
+
+    var scanTimer = null;
+    function scheduleScan() {
+      if (scanTimer) {
+        window.clearTimeout(scanTimer);
+      }
+      scanTimer = window.setTimeout(function () {
+        scanTimer = null;
+        scanUnsizedImages(editor);
+      }, 30);
+    }
+
+    editor.on('SetContent', scheduleScan);
+    editor.on('Change', scheduleScan);
+
+    editor.on('ObjectResized', function (event) {
+      var target = event && event.target;
+      if (target && target.nodeName === 'IMG') {
+        editor.dom.setAttrib(target, SIZED_ATTR, 'true');
+      }
+    });
+
+    editor.on('init', function () {
+      bindImageSizeObserver(editor);
+      scheduleScan();
+    });
+  }
+
+  window.djangoTinyMCESetupContentImage = djangoTinyMCESetupContentImage;
+})();

--- a/static/tinymce/js/tinymce_content_image.js
+++ b/static/tinymce/js/tinymce_content_image.js
@@ -319,14 +319,9 @@
   }
 
   function schedulePostUploadResize(editor, uploadedUrl, knownWidth, knownHeight) {
-    var delays = [0, 30, 100, 250, 500, 1000];
-    for (var d = 0; d < delays.length; d++) {
-      (function (delay) {
-        window.setTimeout(function () {
-          scanUnsizedImages(editor, uploadedUrl, knownWidth, knownHeight);
-        }, delay);
-      })(delays[d]);
-    }
+    window.setTimeout(function () {
+      scanUnsizedImages(editor, uploadedUrl, knownWidth, knownHeight);
+    }, 100);
   }
 
   function getOriginalUploadHandler() {

--- a/static/tinymce/js/tinymce_content_image.js
+++ b/static/tinymce/js/tinymce_content_image.js
@@ -7,6 +7,7 @@
 
   var CONTENT_IMAGE_SIZE = 200;
   var SIZED_ATTR = 'data-mg-content-sized';
+  var CAPTION_ATTR = 'data-mg-caption';
 
   function shouldResize(img, editor) {
     if (!img || img.nodeName !== 'IMG') {
@@ -92,6 +93,214 @@
     }
   }
 
+  function isStandaloneContentImage(img, editor) {
+    return img && img.nodeName === 'IMG' && !editor.dom.getParent(img, '.mg-blog-carousel');
+  }
+
+  function clearImageFloatStyles(editor, img) {
+    editor.dom.setStyle(img, 'float', null);
+    editor.dom.setStyle(img, 'margin-left', null);
+    editor.dom.setStyle(img, 'margin-right', null);
+    var cls = img.className;
+    if (!cls) {
+      return;
+    }
+    var next = cls
+      .replace(/\balign(left|center|right)\b/g, '')
+      .replace(/\s+/g, ' ')
+      .trim();
+    if (next) {
+      img.className = next;
+    } else {
+      img.removeAttribute('class');
+    }
+  }
+
+  function isLayoutBlock(node) {
+    return node && (node.nodeName === 'P' || node.nodeName === 'DIV');
+  }
+
+  function isExcludedImageBlock(node) {
+    if (!node || !node.classList) {
+      return false;
+    }
+    return (
+      node.classList.contains('mg-blog-carousel') ||
+      node.classList.contains('ad-placeholder-rtb-banner')
+    );
+  }
+
+  function getImageOnlyBlockImages(block, editor) {
+    var imgs = [];
+    var c;
+    var node;
+
+    for (c = 0; c < block.childNodes.length; c++) {
+      node = block.childNodes[c];
+      if (node.nodeType === 3) {
+        if (node.nodeValue && node.nodeValue.trim()) {
+          return null;
+        }
+        continue;
+      }
+      if (node.nodeType !== 1) {
+        continue;
+      }
+      if (node.nodeName === 'BR') {
+        continue;
+      }
+      if (node.nodeName === 'IMG' && isStandaloneContentImage(node, editor)) {
+        imgs.push(node);
+        continue;
+      }
+      return null;
+    }
+
+    return imgs.length ? imgs : null;
+  }
+
+  function wrapStandaloneImageInParagraph(editor, img) {
+    if (!isStandaloneContentImage(img, editor)) {
+      return false;
+    }
+    if (editor.dom.getParent(img, 'p,figure', true)) {
+      return false;
+    }
+
+    var p = editor.dom.create('p');
+    img.parentNode.insertBefore(p, img);
+    p.appendChild(img);
+    return true;
+  }
+
+  function splitStackedImagesInBlock(editor, block, imgs) {
+    if (imgs.length <= 1) {
+      return false;
+    }
+
+    var insertAfter = block;
+    var i;
+    var newP;
+
+    if (block.nodeName === 'DIV') {
+      var firstP = editor.dom.create('p');
+      editor.dom.insertBefore(firstP, block);
+      firstP.appendChild(imgs[0]);
+      insertAfter = firstP;
+    }
+
+    for (i = 1; i < imgs.length; i++) {
+      newP = editor.dom.create('p');
+      editor.dom.insertAfter(newP, insertAfter);
+      newP.appendChild(imgs[i]);
+      insertAfter = newP;
+    }
+
+    if (block.nodeName === 'DIV') {
+      editor.dom.remove(block);
+    }
+
+    return true;
+  }
+
+  function normalizeStandaloneImageLayout(editor) {
+    var body = editor.getBody();
+    if (!body) {
+      return false;
+    }
+
+    var changed = false;
+    var imgs = body.getElementsByTagName('img');
+    var i;
+
+    for (i = 0; i < imgs.length; i++) {
+      var img = imgs[i];
+      if (!isStandaloneContentImage(img, editor)) {
+        continue;
+      }
+      clearImageFloatStyles(editor, img);
+      if (wrapStandaloneImageInParagraph(editor, img)) {
+        changed = true;
+      }
+    }
+
+    var blockList = [];
+    var blocks = body.querySelectorAll('p, div');
+    for (i = 0; i < blocks.length; i++) {
+      if (!isLayoutBlock(blocks[i]) || isExcludedImageBlock(blocks[i])) {
+        continue;
+      }
+      if (editor.dom.getParent(blocks[i], '.mg-blog-carousel')) {
+        continue;
+      }
+      blockList.push(blocks[i]);
+    }
+
+    for (i = 0; i < blockList.length; i++) {
+      var block = blockList[i];
+      var blockImgs = getImageOnlyBlockImages(block, editor);
+      if (!blockImgs) {
+        continue;
+      }
+      var k;
+      for (k = 0; k < blockImgs.length; k++) {
+        clearImageFloatStyles(editor, blockImgs[k]);
+      }
+      if (splitStackedImagesInBlock(editor, block, blockImgs)) {
+        changed = true;
+      }
+    }
+
+    return changed;
+  }
+
+  function scanImageLayout(editor) {
+    if (normalizeStandaloneImageLayout(editor)) {
+      editor.nodeChanged();
+      scanCaptionPreviews(editor);
+    }
+  }
+
+  function syncCaptionPreview(editor, img) {
+    if (!img || img.nodeName !== 'IMG') {
+      return;
+    }
+    if (editor.dom.getParent(img, '.mg-blog-carousel')) {
+      return;
+    }
+
+    var alt = (img.getAttribute('alt') || '').trim();
+    var wrapper = editor.dom.getParent(img, 'p,figure', true);
+
+    if (wrapper && !editor.dom.getParent(wrapper, '.mg-blog-carousel')) {
+      if (alt) {
+        editor.dom.setAttrib(wrapper, CAPTION_ATTR, alt);
+      } else {
+        editor.dom.setAttrib(wrapper, CAPTION_ATTR, null);
+      }
+      editor.dom.setAttrib(img, CAPTION_ATTR, null);
+      return;
+    }
+
+    if (alt) {
+      editor.dom.setAttrib(img, CAPTION_ATTR, alt);
+    } else {
+      editor.dom.setAttrib(img, CAPTION_ATTR, null);
+    }
+  }
+
+  function scanCaptionPreviews(editor) {
+    var body = editor.getBody();
+    if (!body) {
+      return;
+    }
+
+    var imgs = body.getElementsByTagName('img');
+    for (var i = 0; i < imgs.length; i++) {
+      syncCaptionPreview(editor, imgs[i]);
+    }
+  }
+
   function scanUnsizedImages(editor, matchUrl, knownWidth, knownHeight) {
     var body = editor.getBody();
     if (!body) {
@@ -105,6 +314,7 @@
         continue;
       }
       applyStandardSize(editor, img, knownWidth, knownHeight);
+      syncCaptionPreview(editor, img);
     }
   }
 
@@ -158,10 +368,12 @@
             }
             if (node.nodeName === 'IMG') {
               applyStandardSize(editor, node);
+              syncCaptionPreview(editor, node);
             } else if (node.querySelectorAll) {
               var addedImgs = node.querySelectorAll('img');
               for (var k = 0; k < addedImgs.length; k++) {
                 applyStandardSize(editor, addedImgs[k]);
+                syncCaptionPreview(editor, addedImgs[k]);
               }
             }
           }
@@ -171,7 +383,13 @@
           if (mutation.attributeName === SIZED_ATTR) {
             continue;
           }
+          if (mutation.attributeName === CAPTION_ATTR) {
+            continue;
+          }
           applyStandardSize(editor, mutation.target);
+          if (mutation.attributeName === 'alt') {
+            syncCaptionPreview(editor, mutation.target);
+          }
         }
       }
     });
@@ -180,7 +398,7 @@
       childList: true,
       subtree: true,
       attributes: true,
-      attributeFilter: ['src', 'width', 'height', 'style']
+      attributeFilter: ['src', 'width', 'height', 'style', 'alt']
     });
   }
 
@@ -201,9 +419,38 @@
     }
   }
 
+  function stripStandaloneCaptionAttrs(html) {
+    var parser = new DOMParser();
+    var doc = parser.parseFromString('<div id="mg-root">' + html + '</div>', 'text/html');
+    var root = doc.getElementById('mg-root');
+    if (!root) {
+      return html;
+    }
+
+    var marked = root.querySelectorAll('[' + CAPTION_ATTR + ']');
+    for (var i = 0; i < marked.length; i++) {
+      var node = marked[i];
+      if (node.classList && node.classList.contains('mg-blog-carousel')) {
+        continue;
+      }
+      if (node.closest && node.closest('.mg-blog-carousel')) {
+        continue;
+      }
+      node.removeAttribute(CAPTION_ATTR);
+    }
+
+    return root.innerHTML;
+  }
+
   function djangoTinyMCESetupContentImage(editor) {
     installUploadHandlerOnEditor(editor);
     bindImageSizeObserver(editor);
+
+    editor.on('PostProcess', function (e) {
+      if (e.get && e.content) {
+        e.content = stripStandaloneCaptionAttrs(e.content);
+      }
+    });
 
     var scanTimer = null;
     function scheduleScan() {
@@ -213,6 +460,8 @@
       scanTimer = window.setTimeout(function () {
         scanTimer = null;
         scanUnsizedImages(editor);
+        scanImageLayout(editor);
+        scanCaptionPreviews(editor);
       }, 30);
     }
 

--- a/static/tinymce/js/tinymce_csrf_upload.js
+++ b/static/tinymce/js/tinymce_csrf_upload.js
@@ -48,15 +48,11 @@
       };
 
       xhr.onload = function () {
-        parseUploadResponse(xhr)
-          .then(function (url) {
-            if (xhr.status >= 200 && xhr.status < 300) {
-              resolve(url);
-              return;
-            }
-            return Promise.reject('Upload failed: ' + xhr.status);
-          })
-          .catch(reject);
+        if (xhr.status < 200 || xhr.status >= 300) {
+          reject('Upload failed: ' + xhr.status);
+          return;
+        }
+        parseUploadResponse(xhr).then(resolve).catch(reject);
       };
 
       xhr.onerror = function () {

--- a/static/tinymce/js/tinymce_csrf_upload.js
+++ b/static/tinymce/js/tinymce_csrf_upload.js
@@ -12,14 +12,67 @@
     return match ? decodeURIComponent(match[1]) : null;
   }
 
-  function djangoTinyMCEImagesUploadHandler(blobInfo, progress) {
+  function parseUploadResponse(xhr) {
+    var data;
+    try {
+      data = JSON.parse(xhr.responseText);
+    } catch (e) {
+      return Promise.reject('Upload failed: invalid response');
+    }
+    if (data.location) {
+      return data.location;
+    }
+    return Promise.reject(data.error || 'No location in response');
+  }
+
+  function uploadViaXhr(file, filename, onProgress) {
+    var csrftoken = getCookie('csrftoken');
+    if (!csrftoken) {
+      return Promise.reject('CSRF token not found');
+    }
+
+    return new Promise(function (resolve, reject) {
+      var xhr = new XMLHttpRequest();
+      var formData = new FormData();
+      formData.append('file', file, filename || file.name || 'image.jpg');
+
+      xhr.open('POST', UPLOAD_URL, true);
+      xhr.setRequestHeader('X-CSRFToken', csrftoken);
+      xhr.withCredentials = true;
+
+      xhr.upload.onprogress = function (event) {
+        if (!onProgress || !event.lengthComputable) {
+          return;
+        }
+        onProgress(Math.round((event.loaded / event.total) * 100));
+      };
+
+      xhr.onload = function () {
+        if (xhr.status >= 200 && xhr.status < 300) {
+          parseUploadResponse(xhr).then(resolve).catch(reject);
+          return;
+        }
+        parseUploadResponse(xhr).catch(function (err) {
+          reject(typeof err === 'string' ? err : 'Upload failed: ' + xhr.status);
+        });
+      };
+
+      xhr.onerror = function () {
+        reject('Upload failed: network error');
+      };
+
+      xhr.send(formData);
+    });
+  }
+
+  function uploadViaFetch(file, filename) {
     var csrftoken = getCookie('csrftoken');
     if (!csrftoken) {
       return Promise.reject('CSRF token not found');
     }
 
     var formData = new FormData();
-    formData.append('file', blobInfo.blob(), blobInfo.filename());
+    formData.append('file', file, filename || file.name || 'image.jpg');
 
     return fetch(UPLOAD_URL, {
       method: 'POST',
@@ -45,5 +98,26 @@
     });
   }
 
+  /**
+   * @param {Blob|File} file
+   * @param {string} [filename]
+   * @param {{ onProgress?: function(number): void }} [options]
+   */
+  function djangoTinyMCEUploadImageFile(file, filename, options) {
+    var onProgress = options && typeof options.onProgress === 'function' ? options.onProgress : null;
+    if (onProgress) {
+      return uploadViaXhr(file, filename, onProgress);
+    }
+    return uploadViaFetch(file, filename);
+  }
+
+  function djangoTinyMCEImagesUploadHandler(blobInfo, progress) {
+    var onProgress = typeof progress === 'function' ? progress : null;
+    return djangoTinyMCEUploadImageFile(blobInfo.blob(), blobInfo.filename(), {
+      onProgress: onProgress
+    });
+  }
+
+  window.djangoTinyMCEUploadImageFile = djangoTinyMCEUploadImageFile;
   window.djangoTinyMCEImagesUploadHandler = djangoTinyMCEImagesUploadHandler;
 })();

--- a/static/tinymce/js/tinymce_csrf_upload.js
+++ b/static/tinymce/js/tinymce_csrf_upload.js
@@ -20,7 +20,7 @@
       return Promise.reject('Upload failed: invalid response');
     }
     if (data.location) {
-      return data.location;
+      return Promise.resolve(data.location);
     }
     return Promise.reject(data.error || 'No location in response');
   }
@@ -48,13 +48,15 @@
       };
 
       xhr.onload = function () {
-        if (xhr.status >= 200 && xhr.status < 300) {
-          parseUploadResponse(xhr).then(resolve).catch(reject);
-          return;
-        }
-        parseUploadResponse(xhr).catch(function (err) {
-          reject(typeof err === 'string' ? err : 'Upload failed: ' + xhr.status);
-        });
+        parseUploadResponse(xhr)
+          .then(function (url) {
+            if (xhr.status >= 200 && xhr.status < 300) {
+              resolve(url);
+              return;
+            }
+            return Promise.reject('Upload failed: ' + xhr.status);
+          })
+          .catch(reject);
       };
 
       xhr.onerror = function () {

--- a/static/tinymce/js/tinymce_setup.js
+++ b/static/tinymce/js/tinymce_setup.js
@@ -11,6 +11,9 @@
     if (typeof window.djangoTinyMCESetupBlogCarousel === 'function') {
       window.djangoTinyMCESetupBlogCarousel(editor);
     }
+    if (typeof window.djangoTinyMCESetupContentImage === 'function') {
+      window.djangoTinyMCESetupContentImage(editor);
+    }
   }
 
   window.djangoTinyMCESetup = djangoTinyMCESetup;

--- a/static/tinymce/js/tinymce_setup.js
+++ b/static/tinymce/js/tinymce_setup.js
@@ -1,0 +1,17 @@
+/**
+ * Общий setup TinyMCE: подключает все кастомные расширения редактора.
+ */
+(function () {
+  'use strict';
+
+  function djangoTinyMCESetup(editor) {
+    if (typeof window.djangoTinyMCESetupRtbBanner === 'function') {
+      window.djangoTinyMCESetupRtbBanner(editor);
+    }
+    if (typeof window.djangoTinyMCESetupBlogCarousel === 'function') {
+      window.djangoTinyMCESetupBlogCarousel(editor);
+    }
+  }
+
+  window.djangoTinyMCESetup = djangoTinyMCESetup;
+})();

--- a/templates/blog/article_detail.html
+++ b/templates/blog/article_detail.html
@@ -6,6 +6,7 @@
     {{ block.super }}
     {% vite_css 'css/tailwind' %}
     {% vite_css 'css/content_image_gallery' %}
+    {% vite_css 'css/blog_content_carousel' %}
 {% endblock %}
 
 {% block extra_js %}


### PR DESCRIPTION
Добавлена карусель фотографий в TinyMCE с редактированием и подписью, единым превью изображений (200px в админке, 500px на сайте) и отображением на странице статьи и в списке статей через Swiper и GLightbox.

Closes #266